### PR TITLE
fix(docker): bump builder image to golang:1.25-alpine

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build stage ---
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Build-time metadata (injected via --build-arg from CI)
 ARG VERSION=dev


### PR DESCRIPTION
## Summary
- `go.mod` requires Go >= 1.25.0, but `deployments/Dockerfile` used `golang:1.22-alpine`, causing `go mod download` to fail during the Docker Build & Push workflow on `main`.
- Bumps the builder stage to `golang:1.25-alpine` to match `go.mod`.

Failed run: https://github.com/nogamsung/claude-ops/actions/runs/24607264728

## Test plan
- [ ] Docker Build & Push workflow succeeds on `main` after merge (linux/amd64 + linux/arm64).
- [ ] Published image runs and `/health` endpoint responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)