### PR TITLE
feat(scheduler): daily/weekly task budget gate + rate-limit auto throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,18 @@ curl http://127.0.0.1:8787/healthz
 # 작업 목록 조회
 curl http://127.0.0.1:8787/tasks?status=queued
 
-# Full usage 모드 활성화 (시간대 게이트 우회)
+# Full usage 모드 활성화 (시간대 게이트 우회 — budget gate 는 그대로 enforced)
 curl -X POST http://127.0.0.1:8787/modes/full \
   -H 'Content-Type: application/json' \
   -d '{"enabled": true}'
+
+# 일일/주간 task 한도 조회 (현재 카운트 + rate-limit 차단 상태 포함)
+curl http://127.0.0.1:8787/modes/limits
+
+# 한도 런타임 오버라이드 (0 → config.yaml 기본값으로 폴백)
+curl -X PATCH http://127.0.0.1:8787/modes/limits \
+  -H 'Content-Type: application/json' \
+  -d '{"daily_max": 10, "weekly_max": 50}'
 
 # 수동 작업 트리거
 curl -X POST http://127.0.0.1:8787/tasks \

--- a/cmd/claude-ops/main.go
+++ b/cmd/claude-ops/main.go
@@ -140,6 +140,18 @@ func run() error {
 	// Use cases.
 	modeUC := usecase.NewModeUseCase(appStateRepo)
 
+	// Resolve task-budget limits (config defaults + derived daily/weekly).
+	dailyMax, weeklyMax, weekStart, resetTZ, err := cfg.Limits.ResolvedLimits()
+	if err != nil {
+		return fmt.Errorf("resolve limits: %w", err)
+	}
+	budgetUC := usecase.NewBudgetUseCase(appStateRepo, scheduler.BudgetLimits{
+		DailyMax:     dailyMax,
+		WeeklyMax:    weeklyMax,
+		WeekStartsOn: weekStart,
+		ResetTZ:      resetTZ,
+	})
+
 	// Worker.
 	workerCfg := scheduler.WorkerConfig{
 		TaskRepo:     taskRepo,
@@ -149,6 +161,7 @@ func run() error {
 		Canceller:    claude.NewProcessCanceller(),
 		Slack:        &schedulerSlackAdapter{client: slackClient},
 		PRCreator:    &schedulerPRAdapter{inner: prCreator},
+		Budget:       budgetUC,
 		Windows:      windows,
 		WorktreeRoot: cfg.Runtime.WorktreeRoot,
 		PromptsDir:   cfg.Runtime.PromptsDir,
@@ -163,6 +176,7 @@ func run() error {
 		AppStateRepo: appStateRepo,
 		Poller:       poller,
 		Worker:       worker,
+		BudgetGate:   budgetUC,
 		TickInterval: cfg.Runtime.TickInterval,
 	})
 
@@ -178,8 +192,9 @@ func run() error {
 	healthH := api.NewHealthHandler(modeUC)
 	taskH := api.NewTaskHandler(taskUC)
 	modeH := api.NewModeHandler(modeUC)
+	limitsH := api.NewLimitsHandler(budgetUC)
 	slackH := api.NewSlackHandler(env.SlackSigningSecret, sched)
-	router := api.NewRouter(healthH, taskH, modeH, slackH)
+	router := api.NewRouter(healthH, taskH, modeH, limitsH, slackH)
 
 	srv := &http.Server{
 		Addr:    cfg.Runtime.HTTPBindAddr,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,17 @@ runtime:
   worktree_root: ".worktrees"
   prompts_dir: "prompts"
 
+limits:
+  # Daily 上限. 0 이면 weekly_max_tasks 에서 자동 유도 (ceil(weekly/7)).
+  # 둘 다 0 이면 무제한.
+  daily_max_tasks: 5
+  # Weekly 上限. 0 이면 daily_max_tasks * 7 로 자동 설정.
+  weekly_max_tasks: 0
+  # 주 시작 요일 — 카운터 리셋 기준 (mon|sun|...)
+  week_starts_on: "mon"
+  # 일/주 카운터 리셋 기준 타임존
+  reset_tz: "Asia/Seoul"
+
 scheduler:
   active_windows:
     - days: ["mon", "tue", "wed", "thu", "fri"]

--- a/docs/specs/claude-ops.md
+++ b/docs/specs/claude-ops.md
@@ -2,7 +2,7 @@
 
 | 항목 | 값 |
 |------|-----|
-| 작성일 | 2026-04-18 |
+| 작성일 | 2026-04-18 (개정 2026-04-19: §2 G7, §5 US-11/US-12, §6.2/6.3, §7 AppState, §8 /modes/limits, §10 R6, §12 OI-4 추가/해소) |
 | 상태 | draft |
 | 스택 범위 | Go (단일 바이너리, 홈서버/VPS 상주) |
 | 우선순위 | P0 |
@@ -26,6 +26,7 @@
 - G4. Slack Stop 버튼 또는 HTTP API 로 실행 중 task 를 **5초 이내** SIGTERM, 30초 내 SIGKILL 보장
 - G5. Full usage 모드 토글 시 활성 시간대 무시하고 **Claude Code usage 한도 신호 감지까지** 연속 실행
 - G6. 단일 Go 바이너리 + systemd unit / Dockerfile 로 배포 (외부 DB·큐 의존성 없음 — SQLite)
+- G7. **Budget gate** (일일/주간 task 카운트 캡 + CLI rate-limit 신호 기반 자동 throttle) 가 항상 enforced — full mode 도 우회 불가. 기본값 daily=5, weekly=daily*7. 운영자가 HTTP API 로 런타임 조절 가능
 
 ## 3. 비목표 (Non-goals)
 
@@ -61,6 +62,8 @@
 | US-8 | 운영자로서 **Slack Stop 버튼** 또는 CLI/HTTP 로 실행 중 task 를 즉시 중단시키고 싶다 | 1) Slack button click → HTTP webhook → 해당 task 의 `claude` pgid 에 SIGTERM <br> 2) 5초 내 미종료 시 SIGKILL <br> 3) worktree `git worktree remove --force` 로 롤백, PR 생성 안 함 <br> 4) Slack 에 `:no_entry: Cancelled` 메시지 <br> 5) Slack signing secret 검증 통과 못하면 요청 거부 |
 | US-9 | 운영자로서 모든 작업 이력을 **조회** 하여 사후 검증하고 싶다 | 1) `GET /tasks?status=...&limit=...` → queued/running/done/failed/cancelled 필터 <br> 2) `GET /tasks/{id}` → 이슈 정보, 시작/종료 시각, 추정 usage, PR URL, stdout 로그 경로 <br> 3) `GET /healthz` 200 OK + scheduler tick 시각 + full-mode 상태 |
 | US-10 | 운영자로서 서비스를 **systemd 또는 Docker** 로 운영하고 싶다 | 1) `deployments/claude-ops.service` 파일 제공 (WorkingDirectory, Restart=on-failure) <br> 2) `deployments/Dockerfile` + `docker-compose.yml` 제공 (volumes: config, db, claude session, git worktrees) <br> 3) 두 배포 모두 `claude` CLI 세션 디렉토리 (`~/.claude`) 와 `gh` 인증 공유 문서화 |
+| US-11 | 운영자로서 **하루/한 주에 돌릴 task 수 상한** 을 두어 플랜 한도 직전까지 가지 않게 하고 싶다 | 1) `config.yaml` 의 `limits: {daily_max_tasks, weekly_max_tasks, week_starts_on, reset_tz}` 로 선언 <br> 2) 둘 중 하나만 설정하면 자동 유도 (daily=ceil(weekly/7), weekly=daily*7), 둘 다 0 이면 무제한 <br> 3) 카운터 리셋은 `reset_tz` 의 자정·`week_starts_on` 의 0시 기준 <br> 4) 일일 한도 도달 → scheduler tick 이 dispatch 스킵 + Slack 통지 (해당 task 는 cancel) <br> 5) `GET /modes/limits` 로 현재 카운터·캡·rate-limit 차단 상태 조회 / `PATCH /modes/limits {daily_max?, weekly_max?}` 로 런타임 오버라이드 (0 → config 값으로 폴백) <br> 6) Full mode 도 우회 못 함 — 한도는 항상 enforced |
+| US-12 | 운영자로서 Claude CLI 가 **rate limit 에 부딪히면 자동으로 멈추고 reset 시각까지 기다리길** 원한다 | 1) `rate_limit_event` 스트림 신호 (`status != "allowed"`) 를 worker 가 감지 → `resetsAt` + `rateLimitType` 을 AppState 에 영속 <br> 2) `now < blocked_until` 인 동안 모든 dispatch 가 budget gate 에서 차단 (Full mode 포함) <br> 3) `usage_warning` task event 기록 + Slack 통지 <br> 4) `now >= blocked_until` 이 되면 다음 tick 부터 자동 재개 — 재시작 불필요 <br> 5) 첫 wall hit 1건은 fail 처리됨 (사전 예측 불가, PRD §10 R6 참조) |
 
 ## 6. 핵심 플로우 (Key Flows)
 
@@ -87,12 +90,13 @@
 ### 6.2 예외 경로
 
 - **윈도우 밖 요청**: scheduler 가 큐에서 pull 하지 않음. 수동 `POST /tasks` 는 409.
-- **Claude usage 한도 감지**: stream-json 에서 rate_limit 시그널 검출 → 진행 중 task 는 graceful stop (chunk 저장) → full mode 자동 해제 → Slack 경고.
+- **Daily/weekly cap 도달**: scheduler tick 이 budget gate 에서 dispatch 스킵 (poll 은 계속). worker 진입한 task 는 claude spawn 직전 카운트 캡 재확인되어 cancel.
+- **Claude usage 한도 감지**: `rate_limit_event` (`status != "allowed"`) → `ErrRateLimited` 로 worker 가 진행 중 task fail 처리 + AppState 에 `rate_limit_block{blocked_until, rate_limit_type}` 영속 → 이후 tick 은 모두 budget gate 에서 차단 → Slack 경고. `now >= blocked_until` 이면 자동 재개. Full mode 자동 해제는 v1 에서 보류 (블록이 더 강한 게이트라 동등한 효과).
 - **PR 생성 실패** (gh 인증 만료·네트워크): Task status=failed, worktree 보존(재시도용), Slack `:x:` 알림 + 로그 snippet.
 - **git push 충돌**: rebase 시도 1회 → 실패 시 fail.
 - **Claude CLI crash**: exit code != 0 → task failed, stderr tail 150줄 Slack 첨부.
 - **Slack webhook 서명 불일치**: 401 반환, 요청 무시.
-- **서비스 재시작**: running 상태 task 는 복구하지 않음 (orphan 표시 + Slack 통지) — Claude CLI 자식 프로세스도 systemd 가 정리.
+- **서비스 재시작**: running 상태 task 는 복구하지 않음 (orphan 표시 + Slack 통지) — Claude CLI 자식 프로세스도 systemd 가 정리. AppState 의 카운터·rate_limit_block 은 보존되어 재시작 후에도 한도 추적 연속성 유지.
 
 ### 6.3 Full usage 모드 플로우
 
@@ -100,9 +104,10 @@
 1. POST /modes/full {enabled: true}
 2. mode 상태 SQLite 에 persist
 3. scheduler 가 active window 게이트 bypass
+   ⚠ budget gate (daily/weekly cap + rate_limit_block) 는 그대로 enforced
 4. 이슈 소진 후에도 idle poll 지속 (30s → 10s 간격 축소)
-5. Claude stdout 에서 rate_limit 또는 usage_warning 감지
-6. 현재 task graceful stop → full mode off → Slack 통지 → 다음 active window 까지 대기
+5. Claude stdout 에서 rate_limit_event 감지 → AppState rate_limit_block 영속
+6. 현재 task fail → 다음 tick 부터 budget gate 가 모든 dispatch 차단 → resetsAt 도달 시 자동 재개
 ```
 
 ## 7. 데이터 모델 (요약)
@@ -121,8 +126,13 @@ TaskEvent (id, task_id FK, kind, payload_json, created_at)
     kind ∈ {started, slack_sent, claude_stdout_chunk, cancelled, usage_warning, pr_created, failed}
 
 AppState (key PK, value_json, updated_at)
-    e.g. key="full_mode", value={enabled: true, enabled_at: ...}
-         key="last_poll_at", value={...}
+    e.g. key="full_mode",         value={enabled: true, enabled_at: ...}
+         key="last_poll_at",      value={...}
+         key="task_counters",     value={daily_count, daily_key:"2026-04-19",
+                                          weekly_count, weekly_key:"2026-W17"}
+         key="rate_limit_block",  value={blocked_until_unix, rate_limit_type:"five_hour",
+                                          observed_at_unix}
+         key="limits_override",   value={daily_max, weekly_max}  # 0 → config 폴백
 ```
 
 관계: `Task 1 ── N TaskEvent`. `AppState` 는 key-value 싱글톤.
@@ -139,6 +149,8 @@ POST   /tasks                      수동 트리거 (repo, issue_number) — win
 POST   /tasks/{id}/stop            강제 중단
 GET    /modes/full                 현재 모드 조회
 POST   /modes/full                 {enabled: bool} 토글
+GET    /modes/limits               현재 일/주 카운터·캡·rate-limit 차단 상태 조회
+PATCH  /modes/limits               {daily_max?, weekly_max?} 런타임 오버라이드 (0=config 폴백)
 POST   /slack/interactions         Slack Block Kit interactive endpoint (signing secret 검증)
 POST   /github/webhook             (선택) issue 이벤트 수신 — polling 보완
 ```
@@ -189,6 +201,7 @@ Slack Block Kit 메시지 스키마 예시:
 - **R3 (Med)**: 동시 worktree 여러 개 존재 시 같은 브랜치 충돌 → v1 은 직렬 실행 1개로 제한, 세마포어 강제
 - **R4 (Low)**: Slack Stop 서명 검증 누락 → 외부 공격자가 임의 kill → signing secret 검증 + timestamp replay 방어 (5분)
 - **R5 (Low)**: SQLite write 동시성 → WAL 모드 + 단일 writer 보장
+- **R6 (Med)**: rate_limit_event 는 "예측" 이 아닌 "반응" — 첫 wall hit 1건은 fail 불가피 (CLI 가 잔여 quota 를 미노출). 완화: daily/weekly task 카운트 캡 (US-11) 으로 wall 도달 전에 자체 throttle. 카운트 캡 보수적으로 잡으면 wall hit 빈도 최소화 가능.
 
 ## 11. 범위 외 (Out of Scope)
 
@@ -219,7 +232,7 @@ Slack Block Kit 메시지 스키마 예시:
 
 - [ ] **OI-2**: 동시 task 병렬 실행 지원 여부. v1 은 직렬 1개 고정이지만 Max 플랜 multi-session 이 허용되면 v1.1 에서 2~3 병렬 검토. 충돌 시나리오 (같은 레포 동시 worktree) 완화 방안 결정 필요.
 - [ ] **OI-3**: PR reviewer 자동 할당 규칙 — 레포 config 의 `reviewers` 배열을 그대로 사용할지, GitHub CODEOWNERS 를 참조할지, 이슈 assignee 를 상속할지.
-- [ ] **OI-4**: Full usage 모드 종료 후 복귀 정책 — rate limit 감지 후 얼마 뒤(예: `resetsAt` + jitter) 다시 full 시도할지, 아니면 다음 active window 까지 무조건 대기할지. (v1 초안: `resetsAt + 60s` 후 재시도, max 3회)
+- [x] **OI-4** (해소 — 2026-04-19, US-11/US-12 와 함께 구현): 별도의 "full mode 자동 해제 + 재시도" 로직 대신 **AppState 의 `rate_limit_block.blocked_until` 단일 게이트** 로 통일. Full mode 는 켜둔 채로 두되 budget gate 가 모든 dispatch 를 차단 → `now >= blocked_until` 이 되면 다음 tick 부터 자연스럽게 재개. jitter 나 max 재시도 카운트는 v1 에서 불필요 (블록이 단일 진실 공급원).
 - [ ] **OI-5**: GitHub webhook 경로 지원 여부 — polling 만으로 충분한가, 아니면 webhook + polling fallback 이 필요한가. (홈서버 외부 노출 리스크 vs 지연)
 - [ ] **OI-6**: Claude CLI 세션 만료 감지 — v1 초안: `system.init.apiKeySource == "none"` 이어야 정상. 만약 `--print` 실행 시 auth prompt 가 stderr 로 나오면 task fail + Slack 긴급 알림. 자동 재로그인 불가 (사람이 SSH 접속해서 `claude login` 필요).
 - [x] **OI-7** (해소 — v1 템플릿 확정): 작업 프롬프트 템플릿 3종 — `prompts/feature.tmpl`, `prompts/security.tmpl`, `prompts/performance.tmpl`. 공통 변수: `{{.Repo}} {{.Issue.Number}} {{.Issue.Title}} {{.Issue.Body}} {{.Issue.Labels}} {{.Branch}} {{.BaseBranch}}`. 공통 지시: ① 작업 브랜치는 이미 체크아웃됨 ② 변경 후 `gh pr create` 는 호출 금지 (서비스가 담당) ③ 커밋만 수행, push 도 서비스가 담당 ④ 외부 네트워크 호출 금지 ⑤ 테스트가 있으면 실행 ⑥ 마지막 assistant 메시지에 `CHANGES:` 섹션으로 변경 요약 출력. 상세 초안은 `./claude-ops-prompt.md` §13 참조.

--- a/internal/api/dto.go
+++ b/internal/api/dto.go
@@ -75,3 +75,38 @@ type FullModeResponse struct {
 type ErrorResponse struct {
 	Error string `json:"error" example:"not found"`
 }
+
+// LimitsResponse is the GET /modes/limits response.
+type LimitsResponse struct {
+	Daily     LimitsDaily     `json:"daily"`
+	Weekly    LimitsWeekly    `json:"weekly"`
+	RateLimit LimitsRateLimit `json:"rate_limit"`
+	Reason    string          `json:"reason,omitempty" example:"daily_cap_reached"`
+}
+
+// LimitsDaily summarises the daily-bucket budget.
+type LimitsDaily struct {
+	Count int    `json:"count" example:"3"`
+	Max   int    `json:"max" example:"5"`
+	Date  string `json:"date" example:"2026-04-19"`
+}
+
+// LimitsWeekly summarises the weekly-bucket budget.
+type LimitsWeekly struct {
+	Count int    `json:"count" example:"12"`
+	Max   int    `json:"max" example:"35"`
+	Week  string `json:"week" example:"2026-W17"`
+}
+
+// LimitsRateLimit reports the currently observed CLI rate-limit block.
+type LimitsRateLimit struct {
+	BlockedUntil  *time.Time `json:"blocked_until,omitempty"`
+	RateLimitType string     `json:"rate_limit_type,omitempty" example:"five_hour"`
+}
+
+// LimitsPatchRequest is the PATCH /modes/limits request body.
+// Either field may be omitted (or set to 0) to fall back to the config-derived value.
+type LimitsPatchRequest struct {
+	DailyMax  *int `json:"daily_max,omitempty" example:"5"`
+	WeeklyMax *int `json:"weekly_max,omitempty" example:"35"`
+}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gs97ahn/claude-ops/internal/api"
 	"github.com/gs97ahn/claude-ops/internal/domain"
+	"github.com/gs97ahn/claude-ops/internal/scheduler"
 	"github.com/gs97ahn/claude-ops/internal/usecase"
 )
 
@@ -100,13 +101,15 @@ func setupRouter(taskRepo *fakeTaskRepo, appStateRepo *fakeAppStateRepo) *gin.En
 	canceller := &fakeCanceller{}
 	taskUC := usecase.NewTaskUseCase(taskRepo, &fakeEventRepo{}, appStateRepo, canceller, nil)
 	modeUC := usecase.NewModeUseCase(appStateRepo)
+	budgetUC := usecase.NewBudgetUseCase(appStateRepo, scheduler.BudgetLimits{})
 
 	healthH := api.NewHealthHandler(modeUC)
 	taskH := api.NewTaskHandler(taskUC)
 	modeH := api.NewModeHandler(modeUC)
+	limitsH := api.NewLimitsHandler(budgetUC)
 	slackH := api.NewSlackHandler("test-secret", canceller)
 
-	return api.NewRouter(healthH, taskH, modeH, slackH)
+	return api.NewRouter(healthH, taskH, modeH, limitsH, slackH)
 }
 
 func TestHealthEndpoint(t *testing.T) {

--- a/internal/api/limits_handler.go
+++ b/internal/api/limits_handler.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gs97ahn/claude-ops/internal/usecase"
+)
+
+// LimitsHandler handles /modes/limits endpoints.
+type LimitsHandler struct {
+	budgetUC *usecase.BudgetUseCase
+}
+
+// NewLimitsHandler creates a LimitsHandler.
+func NewLimitsHandler(budgetUC *usecase.BudgetUseCase) *LimitsHandler {
+	return &LimitsHandler{budgetUC: budgetUC}
+}
+
+// GetLimits godoc
+//
+//	@Summary      Get current task limits and counters
+//	@Description  Returns daily/weekly task counters, configured caps, and any active CLI rate-limit block.
+//	@Tags         modes
+//	@Produce      json
+//	@Success      200  {object}  LimitsResponse
+//	@Router       /modes/limits [get]
+func (h *LimitsHandler) GetLimits(c *gin.Context) {
+	snap, err := h.budgetUC.Snapshot(c.Request.Context(), time.Now())
+	if err != nil {
+		mapError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, snapshotToResponse(snap))
+}
+
+// PatchLimits godoc
+//
+//	@Summary      Override the configured daily/weekly task caps
+//	@Description  Persists a runtime override of the daily and/or weekly task cap. A value of 0 falls back to the config-derived default.
+//	@Tags         modes
+//	@Accept       json
+//	@Produce      json
+//	@Param        request  body      LimitsPatchRequest  true  "Override values"
+//	@Success      200      {object}  LimitsResponse
+//	@Failure      400      {object}  ErrorResponse
+//	@Router       /modes/limits [patch]
+func (h *LimitsHandler) PatchLimits(c *gin.Context) {
+	var req LimitsPatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
+		return
+	}
+	daily := 0
+	if req.DailyMax != nil {
+		daily = *req.DailyMax
+	}
+	weekly := 0
+	if req.WeeklyMax != nil {
+		weekly = *req.WeeklyMax
+	}
+	if _, err := h.budgetUC.SetLimits(c.Request.Context(), daily, weekly); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	snap, err := h.budgetUC.Snapshot(c.Request.Context(), time.Now())
+	if err != nil {
+		mapError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, snapshotToResponse(snap))
+}
+
+func snapshotToResponse(snap usecase.BudgetSnapshot) LimitsResponse {
+	resp := LimitsResponse{
+		Daily: LimitsDaily{
+			Count: snap.Counters.DailyCount,
+			Max:   snap.Limits.DailyMax,
+			Date:  snap.Counters.DailyKey,
+		},
+		Weekly: LimitsWeekly{
+			Count: snap.Counters.WeeklyCount,
+			Max:   snap.Limits.WeeklyMax,
+			Week:  snap.Counters.WeeklyKey,
+		},
+		Reason: string(snap.Reason),
+	}
+	if snap.Block.Active(time.Now()) {
+		until := snap.Block.BlockedUntil
+		resp.RateLimit = LimitsRateLimit{
+			BlockedUntil:  &until,
+			RateLimitType: snap.Block.RateLimitType,
+		}
+	}
+	return resp
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ func NewRouter(
 	healthHandler *HealthHandler,
 	taskHandler *TaskHandler,
 	modeHandler *ModeHandler,
+	limitsHandler *LimitsHandler,
 	slackHandler *SlackHandler,
 ) *gin.Engine {
 	r := gin.New()
@@ -34,6 +35,10 @@ func NewRouter(
 	// Full mode
 	r.GET("/modes/full", modeHandler.GetFullMode)
 	r.POST("/modes/full", modeHandler.SetFullMode)
+
+	// Task budget limits
+	r.GET("/modes/limits", limitsHandler.GetLimits)
+	r.PATCH("/modes/limits", limitsHandler.PatchLimits)
 
 	// Slack
 	r.POST("/slack/interactions", slackHandler.HandleInteractions)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,19 @@ import (
 type Config struct {
 	Runtime   RuntimeConfig   `mapstructure:"runtime"`
 	Scheduler SchedulerConfig `mapstructure:"scheduler"`
+	Limits    LimitsConfig    `mapstructure:"limits"`
 	GitHub    GitHubConfig    `mapstructure:"github"`
 	Slack     SlackConfig     `mapstructure:"slack"`
+}
+
+// LimitsConfig caps how many tasks may run per day/week and how the buckets reset.
+// Either DailyMaxTasks or WeeklyMaxTasks may be 0; defaults derive the missing
+// one from the other (daily = ceil(weekly/7); weekly = daily*7).
+type LimitsConfig struct {
+	DailyMaxTasks  int    `mapstructure:"daily_max_tasks"`
+	WeeklyMaxTasks int    `mapstructure:"weekly_max_tasks"`
+	WeekStartsOn   string `mapstructure:"week_starts_on"` // mon|sun
+	ResetTZ        string `mapstructure:"reset_tz"`       // IANA tz, e.g. "Asia/Seoul"
 }
 
 // RuntimeConfig holds server and storage settings.
@@ -93,6 +104,10 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("runtime.worktree_root", ".worktrees")
 	v.SetDefault("runtime.prompts_dir", "prompts")
 	v.SetDefault("github.poll_interval", "60s")
+	v.SetDefault("limits.daily_max_tasks", 5)
+	v.SetDefault("limits.weekly_max_tasks", 0) // 0 → derived = daily * 7
+	v.SetDefault("limits.week_starts_on", "mon")
+	v.SetDefault("limits.reset_tz", "Asia/Seoul")
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("read config %q: %w", path, err)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -22,7 +22,82 @@ func (c *Config) Validate() error {
 	if c.GitHub.PollInterval <= 0 {
 		return fmt.Errorf("github.poll_interval must be positive")
 	}
+	if err := c.validateLimits(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (c *Config) validateLimits() error {
+	if c.Limits.DailyMaxTasks < 0 {
+		return fmt.Errorf("limits.daily_max_tasks must be >= 0")
+	}
+	if c.Limits.WeeklyMaxTasks < 0 {
+		return fmt.Errorf("limits.weekly_max_tasks must be >= 0")
+	}
+	if c.Limits.WeekStartsOn != "" {
+		if _, ok := weekStartMap[strings.ToLower(c.Limits.WeekStartsOn)]; !ok {
+			return fmt.Errorf("limits.week_starts_on %q must be mon|tue|wed|thu|fri|sat|sun", c.Limits.WeekStartsOn)
+		}
+	}
+	if c.Limits.ResetTZ != "" {
+		if _, err := time.LoadLocation(c.Limits.ResetTZ); err != nil {
+			return fmt.Errorf("limits.reset_tz %q: %w", c.Limits.ResetTZ, err)
+		}
+	}
+	if c.Limits.DailyMaxTasks > 0 && c.Limits.WeeklyMaxTasks > 0 &&
+		c.Limits.DailyMaxTasks > c.Limits.WeeklyMaxTasks {
+		return fmt.Errorf("limits.daily_max_tasks (%d) must be <= weekly_max_tasks (%d)",
+			c.Limits.DailyMaxTasks, c.Limits.WeeklyMaxTasks)
+	}
+	return nil
+}
+
+// weekStartMap maps lowercase day abbreviation to time.Weekday for limits config.
+var weekStartMap = map[string]time.Weekday{
+	"sun": time.Sunday,
+	"mon": time.Monday,
+	"tue": time.Tuesday,
+	"wed": time.Wednesday,
+	"thu": time.Thursday,
+	"fri": time.Friday,
+	"sat": time.Saturday,
+}
+
+// ResolvedLimits returns concrete daily/weekly caps with derived defaults applied:
+//   - both zero → unlimited (both stay 0)
+//   - only daily set → weekly = daily * 7
+//   - only weekly set → daily = ceil(weekly / 7)
+func (c *LimitsConfig) ResolvedLimits() (dailyMax, weeklyMax int, weekStart time.Weekday, tz *time.Location, err error) {
+	dailyMax = c.DailyMaxTasks
+	weeklyMax = c.WeeklyMaxTasks
+	switch {
+	case dailyMax == 0 && weeklyMax > 0:
+		dailyMax = (weeklyMax + 6) / 7
+	case weeklyMax == 0 && dailyMax > 0:
+		weeklyMax = dailyMax * 7
+	}
+
+	startName := strings.ToLower(c.WeekStartsOn)
+	if startName == "" {
+		startName = "mon"
+	}
+	wd, ok := weekStartMap[startName]
+	if !ok {
+		return 0, 0, 0, nil, fmt.Errorf("invalid week_starts_on %q", c.WeekStartsOn)
+	}
+	weekStart = wd
+
+	tzName := c.ResetTZ
+	if tzName == "" {
+		tzName = "UTC"
+	}
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return 0, 0, 0, nil, fmt.Errorf("load tz %q: %w", tzName, err)
+	}
+	tz = loc
+	return dailyMax, weeklyMax, weekStart, tz, nil
 }
 
 func (c *Config) validateWindows() error {

--- a/internal/scheduler/budget_gate.go
+++ b/internal/scheduler/budget_gate.go
@@ -1,0 +1,106 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+)
+
+// BudgetLimits is the configured ceiling for daily/weekly task counts.
+type BudgetLimits struct {
+	DailyMax     int
+	WeeklyMax    int
+	WeekStartsOn time.Weekday
+	ResetTZ      *time.Location
+}
+
+// BudgetCounters holds the persisted task counts for the current day/week buckets.
+type BudgetCounters struct {
+	DailyCount  int
+	DailyKey    string // e.g. "2026-04-19"
+	WeeklyCount int
+	WeeklyKey   string // e.g. "2026-W17"
+}
+
+// RateLimitBlock represents an observed CLI rate-limit signal.
+// Zero value means no active block.
+type RateLimitBlock struct {
+	BlockedUntil  time.Time // zero if none
+	RateLimitType string
+}
+
+// Active reports whether the block is still in effect at now.
+func (b RateLimitBlock) Active(now time.Time) bool {
+	return !b.BlockedUntil.IsZero() && now.Before(b.BlockedUntil)
+}
+
+// BudgetReason explains a budget gate decision. Empty string means "allowed".
+type BudgetReason string
+
+// BudgetReasonAllowed and siblings enumerate budget gate decisions.
+const (
+	BudgetReasonAllowed     BudgetReason = ""
+	BudgetReasonDailyCap    BudgetReason = "daily_cap_reached"
+	BudgetReasonWeeklyCap   BudgetReason = "weekly_cap_reached"
+	BudgetReasonRateLimited BudgetReason = "rate_limited"
+)
+
+// EvaluateBudget reports whether a new task may start at now.
+// Caller is expected to have already performed bucket rollover (RolloverCounters).
+// Limits with zero or negative max values are treated as "no limit".
+func EvaluateBudget(now time.Time, counters BudgetCounters, limits BudgetLimits, block RateLimitBlock) BudgetReason {
+	if block.Active(now) {
+		return BudgetReasonRateLimited
+	}
+	if limits.DailyMax > 0 && counters.DailyCount >= limits.DailyMax {
+		return BudgetReasonDailyCap
+	}
+	if limits.WeeklyMax > 0 && counters.WeeklyCount >= limits.WeeklyMax {
+		return BudgetReasonWeeklyCap
+	}
+	return BudgetReasonAllowed
+}
+
+// DateKey returns "YYYY-MM-DD" in the limits TZ for use as the daily counter bucket.
+func DateKey(now time.Time, tz *time.Location) string {
+	if tz == nil {
+		tz = time.UTC
+	}
+	return now.In(tz).Format("2006-01-02")
+}
+
+// WeekKey returns "YYYY-Www" identifying the week bucket (TZ-local), where the
+// week starts on the configured weekday. The result is monotonic within a year
+// and stable across DST shifts because it is derived from the local date only.
+func WeekKey(now time.Time, tz *time.Location, weekStartsOn time.Weekday) string {
+	if tz == nil {
+		tz = time.UTC
+	}
+	local := now.In(tz)
+	// Snap to the most recent week start.
+	offset := int(local.Weekday()-weekStartsOn+7) % 7
+	weekStart := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, tz).
+		AddDate(0, 0, -offset)
+	year, week := weekStart.ISOWeek()
+	// ISOWeek anchors on Monday; for non-Monday week starts the displayed
+	// year/week may diverge from ISO. We still get a unique-per-week key.
+	return fmt.Sprintf("%04d-W%02d", year, week)
+}
+
+// RolloverCounters returns counters reset to zero when the day/week key has
+// changed relative to now. If the bucket is still current the counters are
+// returned unchanged (with empty keys filled in).
+func RolloverCounters(now time.Time, counters BudgetCounters, limits BudgetLimits) BudgetCounters {
+	dailyKey := DateKey(now, limits.ResetTZ)
+	weeklyKey := WeekKey(now, limits.ResetTZ, limits.WeekStartsOn)
+
+	out := counters
+	if out.DailyKey != dailyKey {
+		out.DailyKey = dailyKey
+		out.DailyCount = 0
+	}
+	if out.WeeklyKey != weeklyKey {
+		out.WeeklyKey = weeklyKey
+		out.WeeklyCount = 0
+	}
+	return out
+}

--- a/internal/scheduler/budget_gate_test.go
+++ b/internal/scheduler/budget_gate_test.go
@@ -1,0 +1,172 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gs97ahn/claude-ops/internal/scheduler"
+)
+
+func mustLoc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("load location %q: %v", name, err)
+	}
+	return loc
+}
+
+func TestEvaluateBudget_AllowedWhenUnderCaps(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 1, WeeklyCount: 3}
+	l := scheduler.BudgetLimits{DailyMax: 5, WeeklyMax: 35}
+	if got := scheduler.EvaluateBudget(now, c, l, scheduler.RateLimitBlock{}); got != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed, got %q", got)
+	}
+}
+
+func TestEvaluateBudget_RateLimitedTakesPrecedence(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 0, WeeklyCount: 0}
+	l := scheduler.BudgetLimits{DailyMax: 5, WeeklyMax: 35}
+	block := scheduler.RateLimitBlock{
+		BlockedUntil:  now.Add(2 * time.Hour),
+		RateLimitType: "five_hour",
+	}
+	if got := scheduler.EvaluateBudget(now, c, l, block); got != scheduler.BudgetReasonRateLimited {
+		t.Errorf("expected rate_limited, got %q", got)
+	}
+}
+
+func TestEvaluateBudget_BlockExpired(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 0, WeeklyCount: 0}
+	l := scheduler.BudgetLimits{DailyMax: 5, WeeklyMax: 35}
+	block := scheduler.RateLimitBlock{
+		BlockedUntil:  now.Add(-1 * time.Minute), // already passed
+		RateLimitType: "five_hour",
+	}
+	if got := scheduler.EvaluateBudget(now, c, l, block); got != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed (block expired), got %q", got)
+	}
+}
+
+func TestEvaluateBudget_DailyCapReached(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 5, WeeklyCount: 5}
+	l := scheduler.BudgetLimits{DailyMax: 5, WeeklyMax: 35}
+	if got := scheduler.EvaluateBudget(now, c, l, scheduler.RateLimitBlock{}); got != scheduler.BudgetReasonDailyCap {
+		t.Errorf("expected daily_cap_reached, got %q", got)
+	}
+}
+
+func TestEvaluateBudget_WeeklyCapReached(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 1, WeeklyCount: 35}
+	l := scheduler.BudgetLimits{DailyMax: 5, WeeklyMax: 35}
+	if got := scheduler.EvaluateBudget(now, c, l, scheduler.RateLimitBlock{}); got != scheduler.BudgetReasonWeeklyCap {
+		t.Errorf("expected weekly_cap_reached, got %q", got)
+	}
+}
+
+func TestEvaluateBudget_ZeroLimitMeansUnlimited(t *testing.T) {
+	now := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	c := scheduler.BudgetCounters{DailyCount: 9999, WeeklyCount: 9999}
+	l := scheduler.BudgetLimits{DailyMax: 0, WeeklyMax: 0}
+	if got := scheduler.EvaluateBudget(now, c, l, scheduler.RateLimitBlock{}); got != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed for zero limits, got %q", got)
+	}
+}
+
+func TestRolloverCounters_DailyKeyChange(t *testing.T) {
+	seoul := mustLoc(t, "Asia/Seoul")
+	limits := scheduler.BudgetLimits{
+		DailyMax:     5,
+		WeeklyMax:    35,
+		WeekStartsOn: time.Monday,
+		ResetTZ:      seoul,
+	}
+	prev := scheduler.BudgetCounters{
+		DailyCount:  4,
+		DailyKey:    "2026-04-18",
+		WeeklyCount: 10,
+		WeeklyKey:   "2026-W16",
+	}
+	now := time.Date(2026, 4, 19, 1, 0, 0, 0, seoul) // next day in Seoul
+	out := scheduler.RolloverCounters(now, prev, limits)
+
+	if out.DailyCount != 0 {
+		t.Errorf("expected daily count reset, got %d", out.DailyCount)
+	}
+	if out.DailyKey != "2026-04-19" {
+		t.Errorf("expected daily key 2026-04-19, got %q", out.DailyKey)
+	}
+	// 2026-04-19 is Sunday — same week (Mon..Sun) as 2026-04-13..04-19.
+	// Weekly should NOT roll over when only the day changed within the same week.
+	if out.WeeklyCount != 10 {
+		t.Errorf("expected weekly count preserved, got %d", out.WeeklyCount)
+	}
+}
+
+func TestRolloverCounters_WeeklyKeyChange(t *testing.T) {
+	seoul := mustLoc(t, "Asia/Seoul")
+	limits := scheduler.BudgetLimits{
+		DailyMax:     5,
+		WeeklyMax:    35,
+		WeekStartsOn: time.Monday,
+		ResetTZ:      seoul,
+	}
+	// Start: counters for previous week (Mon 2026-04-13 .. Sun 2026-04-19)
+	prev := scheduler.BudgetCounters{
+		DailyCount:  3,
+		DailyKey:    "2026-04-19",
+		WeeklyCount: 25,
+		WeeklyKey:   scheduler.WeekKey(time.Date(2026, 4, 19, 12, 0, 0, 0, seoul), seoul, time.Monday),
+	}
+	// Now: Monday 2026-04-20 — new week begins
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, seoul)
+	out := scheduler.RolloverCounters(now, prev, limits)
+
+	if out.DailyCount != 0 {
+		t.Errorf("expected daily reset on new day, got %d", out.DailyCount)
+	}
+	if out.WeeklyCount != 0 {
+		t.Errorf("expected weekly reset on new week, got %d", out.WeeklyCount)
+	}
+}
+
+func TestRolloverCounters_NoChangeWithinSameBucket(t *testing.T) {
+	seoul := mustLoc(t, "Asia/Seoul")
+	limits := scheduler.BudgetLimits{
+		DailyMax:     5,
+		WeeklyMax:    35,
+		WeekStartsOn: time.Monday,
+		ResetTZ:      seoul,
+	}
+	dailyKey := "2026-04-20"
+	weeklyKey := scheduler.WeekKey(time.Date(2026, 4, 20, 9, 0, 0, 0, seoul), seoul, time.Monday)
+	prev := scheduler.BudgetCounters{
+		DailyCount:  3,
+		DailyKey:    dailyKey,
+		WeeklyCount: 8,
+		WeeklyKey:   weeklyKey,
+	}
+	now := time.Date(2026, 4, 20, 23, 30, 0, 0, seoul)
+	out := scheduler.RolloverCounters(now, prev, limits)
+
+	if out.DailyCount != 3 || out.WeeklyCount != 8 {
+		t.Errorf("expected counters preserved, got daily=%d weekly=%d", out.DailyCount, out.WeeklyCount)
+	}
+}
+
+func TestDateKey_TZBoundary(t *testing.T) {
+	seoul := mustLoc(t, "Asia/Seoul")
+	// UTC 14:30 = Seoul 23:30 (same day Apr 19)
+	if got := scheduler.DateKey(time.Date(2026, 4, 19, 14, 30, 0, 0, time.UTC), seoul); got != "2026-04-19" {
+		t.Errorf("expected 2026-04-19, got %q", got)
+	}
+	// UTC 15:01 = Seoul 00:01 next day (Apr 20)
+	if got := scheduler.DateKey(time.Date(2026, 4, 19, 15, 1, 0, 0, time.UTC), seoul); got != "2026-04-20" {
+		t.Errorf("expected 2026-04-20 (TZ rollover), got %q", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -24,6 +24,12 @@ type WorkerRunner interface {
 	RunTask(ctx context.Context, task *domain.Task) error
 }
 
+// BudgetGate reports whether a new task may be dispatched at now and why not
+// when refused. The empty BudgetReason means allowed.
+type BudgetGate interface {
+	SnapshotReason(ctx context.Context, now time.Time) (BudgetReason, error)
+}
+
 // Scheduler drives the tick loop and dispatches tasks within active windows.
 type Scheduler struct {
 	clock        Clock
@@ -32,6 +38,7 @@ type Scheduler struct {
 	appStateRepo domain.AppStateRepository
 	poller       Poller
 	worker       WorkerRunner
+	budgetGate   BudgetGate
 
 	tickInterval time.Duration
 
@@ -54,6 +61,7 @@ type Config struct {
 	AppStateRepo domain.AppStateRepository
 	Poller       Poller
 	Worker       WorkerRunner
+	BudgetGate   BudgetGate
 	TickInterval time.Duration
 }
 
@@ -72,6 +80,7 @@ func New(cfg Config) *Scheduler {
 		appStateRepo: cfg.AppStateRepo,
 		poller:       cfg.Poller,
 		worker:       cfg.Worker,
+		budgetGate:   cfg.BudgetGate,
 		tickInterval: cfg.TickInterval,
 		sem:          make(chan struct{}, 1),
 		cancelMap:    make(map[string]context.CancelFunc),
@@ -128,10 +137,23 @@ func (s *Scheduler) tick(ctx context.Context) {
 		return
 	}
 
-	// Poll for new issues.
+	// Poll for new issues regardless of budget — polling is free and lets
+	// queued items accumulate for when the gate reopens.
 	if s.poller != nil {
 		if err := s.poller.Poll(ctx); err != nil {
 			slog.Error("scheduler: poller error", "err", err)
+		}
+	}
+
+	// Budget gate (daily/weekly task cap + observed CLI rate-limit block).
+	// Always enforced — even in full mode we refuse to spawn past these caps.
+	if s.budgetGate != nil {
+		reason, err := s.budgetGate.SnapshotReason(ctx, s.clock.Now())
+		if err != nil {
+			slog.Warn("scheduler: budget snapshot error", "err", err)
+		} else if reason != BudgetReasonAllowed {
+			slog.Debug("scheduler: budget gate blocks dispatch", "reason", string(reason))
+			return
 		}
 	}
 

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/gs97ahn/claude-ops/internal/claude"
+	"github.com/gs97ahn/claude-ops/internal/claude/stream"
 	"github.com/gs97ahn/claude-ops/internal/domain"
 )
 
@@ -30,6 +32,14 @@ type PRCreator interface {
 	CreatePR(ctx context.Context, task *domain.Task) (string, int, error)
 }
 
+// BudgetEnforcer is the worker-side hook for the daily/weekly task budget.
+// CheckAndIncrementReason atomically reserves a slot; RecordRateLimitBlock
+// persists an observed CLI rate-limit signal so subsequent ticks back off.
+type BudgetEnforcer interface {
+	CheckAndIncrementReason(ctx context.Context, now time.Time) (BudgetReason, error)
+	RecordRateLimitBlock(ctx context.Context, resetsAtUnix int64, rateLimitType string, observedAt time.Time) error
+}
+
 // WorkerConfig holds dependencies for the Worker.
 type WorkerConfig struct {
 	TaskRepo     domain.TaskRepository
@@ -39,6 +49,7 @@ type WorkerConfig struct {
 	Canceller    claude.Canceller
 	Slack        SlackNotifier
 	PRCreator    PRCreator
+	Budget       BudgetEnforcer
 	Clock        Clock
 	Windows      []*domain.ActiveWindow
 	WorktreeRoot string
@@ -121,6 +132,23 @@ func (w *Worker) RunTask(ctx context.Context, task *domain.Task) error {
 		return w.cancel(ctx, task)
 	}
 
+	// Budget gate (atomic check + counter increment) — last gate before claude
+	// spawn. Always enforced: even in full mode the daily/weekly cap and any
+	// observed rate-limit block apply, since they are the very limits full
+	// mode must respect to avoid plan exhaustion.
+	if w.cfg.Budget != nil {
+		reason, err := w.cfg.Budget.CheckAndIncrementReason(ctx, w.cfg.Clock.Now())
+		if err != nil {
+			_ = w.removeWorktree(task.WorktreePath)
+			return w.fail(ctx, task, fmt.Sprintf("budget gate error: %v", err))
+		}
+		if reason != BudgetReasonAllowed {
+			slog.Info("worker: budget gate blocks task", "task_id", task.ID, "reason", string(reason))
+			_ = w.removeWorktree(task.WorktreePath)
+			return w.cancel(ctx, task)
+		}
+	}
+
 	// Run Claude.
 	gate := &funcWindowGate{fn: func(t time.Time, fm bool) bool {
 		return AllowNow(t, fm, w.cfg.Windows)
@@ -143,6 +171,7 @@ func (w *Worker) RunTask(ctx context.Context, task *domain.Task) error {
 
 	// Handle Claude errors.
 	if runErr != nil {
+		w.maybeRecordRateLimit(ctx, task, runErr)
 		slog.Error("worker: claude run failed", "err", runErr, "task_id", task.ID)
 		stderrTail := ""
 		if result != nil {
@@ -312,6 +341,27 @@ func (w *Worker) isFullMode(ctx context.Context) bool {
 		return false
 	}
 	return len(state.ValueJSON) > 0 && containsTrue(state.ValueJSON)
+}
+
+// maybeRecordRateLimit detects an *stream.ErrRateLimited from the runner and
+// persists the block via the BudgetEnforcer. Best-effort — failures are logged
+// but do not change the surrounding error path.
+func (w *Worker) maybeRecordRateLimit(ctx context.Context, task *domain.Task, runErr error) {
+	if w.cfg.Budget == nil || runErr == nil {
+		return
+	}
+	var rl *stream.ErrRateLimited
+	if !errors.As(runErr, &rl) {
+		return
+	}
+	now := w.cfg.Clock.Now()
+	if err := w.cfg.Budget.RecordRateLimitBlock(ctx, rl.ResetsAt, rl.RateLimitType, now); err != nil {
+		slog.Warn("worker: record rate-limit block", "err", err, "task_id", task.ID)
+	}
+	w.recordEvent(ctx, task.ID, domain.EventKindUsageWarning, map[string]interface{}{
+		"resets_at_unix":  rl.ResetsAt,
+		"rate_limit_type": rl.RateLimitType,
+	})
 }
 
 // funcWindowGate adapts a function to the claude.WindowGate interface.

--- a/internal/usecase/budget_usecase.go
+++ b/internal/usecase/budget_usecase.go
@@ -1,0 +1,283 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gs97ahn/claude-ops/internal/domain"
+	"github.com/gs97ahn/claude-ops/internal/scheduler"
+)
+
+const (
+	appStateKeyTaskCounters   = "task_counters"
+	appStateKeyRateLimitBlock = "rate_limit_block"
+	appStateKeyLimitsOverride = "limits_override"
+)
+
+// taskCountersJSON is the persisted shape of BudgetCounters.
+type taskCountersJSON struct {
+	DailyCount  int    `json:"daily_count"`
+	DailyKey    string `json:"daily_key"`
+	WeeklyCount int    `json:"weekly_count"`
+	WeeklyKey   string `json:"weekly_key"`
+}
+
+// rateLimitBlockJSON is the persisted shape of RateLimitBlock.
+type rateLimitBlockJSON struct {
+	BlockedUntilUnix int64  `json:"blocked_until_unix"`
+	RateLimitType    string `json:"rate_limit_type"`
+	ObservedAtUnix   int64  `json:"observed_at_unix"`
+}
+
+// limitsOverrideJSON persists runtime adjustments to the configured caps.
+// A zero value falls back to the config-derived value.
+type limitsOverrideJSON struct {
+	DailyMax  int `json:"daily_max"`
+	WeeklyMax int `json:"weekly_max"`
+}
+
+// BudgetSnapshot is the consolidated budget state returned to API/scheduler callers.
+type BudgetSnapshot struct {
+	Counters scheduler.BudgetCounters
+	Limits   scheduler.BudgetLimits
+	Block    scheduler.RateLimitBlock
+	Reason   scheduler.BudgetReason // result of EvaluateBudget at the snapshot time
+}
+
+// BudgetUseCase persists task counters and rate-limit blocks.
+//
+// All reads/writes go through a single mutex so increment-after-rollover stays
+// race-free at the in-process level. SQLite is the single writer too, so there
+// is no second writer to coordinate with.
+type BudgetUseCase struct {
+	appStateRepo domain.AppStateRepository
+	configLimits scheduler.BudgetLimits
+	mu           sync.Mutex
+}
+
+// NewBudgetUseCase creates a BudgetUseCase using configLimits as the baseline,
+// optionally overridden at runtime via SetLimits.
+func NewBudgetUseCase(appStateRepo domain.AppStateRepository, configLimits scheduler.BudgetLimits) *BudgetUseCase {
+	return &BudgetUseCase{
+		appStateRepo: appStateRepo,
+		configLimits: configLimits,
+	}
+}
+
+// Snapshot returns the rolled-over counters, effective limits, current block
+// and the gate decision at now.
+func (uc *BudgetUseCase) Snapshot(ctx context.Context, now time.Time) (BudgetSnapshot, error) {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+	return uc.snapshotLocked(ctx, now)
+}
+
+// SnapshotReason satisfies scheduler.BudgetGate — returns just the gate decision.
+func (uc *BudgetUseCase) SnapshotReason(ctx context.Context, now time.Time) (scheduler.BudgetReason, error) {
+	snap, err := uc.Snapshot(ctx, now)
+	if err != nil {
+		return "", err
+	}
+	return snap.Reason, nil
+}
+
+// CheckAndIncrementReason satisfies scheduler.BudgetEnforcer — returns just
+// the gate decision after the atomic check+increment.
+func (uc *BudgetUseCase) CheckAndIncrementReason(ctx context.Context, now time.Time) (scheduler.BudgetReason, error) {
+	reason, _, err := uc.CheckAndIncrement(ctx, now)
+	return reason, err
+}
+
+// CheckAndIncrement atomically evaluates the budget gate and, if allowed,
+// increments the counters in storage. It returns the reason (empty string for
+// allowed) along with the post-increment snapshot.
+func (uc *BudgetUseCase) CheckAndIncrement(ctx context.Context, now time.Time) (scheduler.BudgetReason, BudgetSnapshot, error) {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+
+	snap, err := uc.snapshotLocked(ctx, now)
+	if err != nil {
+		return "", snap, err
+	}
+	if snap.Reason != scheduler.BudgetReasonAllowed {
+		return snap.Reason, snap, nil
+	}
+
+	snap.Counters.DailyCount++
+	snap.Counters.WeeklyCount++
+	if err := uc.persistCountersLocked(ctx, snap.Counters); err != nil {
+		return "", snap, err
+	}
+	return scheduler.BudgetReasonAllowed, snap, nil
+}
+
+// RecordRateLimitBlock persists a CLI-observed rate-limit signal.
+// resetsAtUnix is the unix-seconds value reported in rate_limit_event.resetsAt.
+func (uc *BudgetUseCase) RecordRateLimitBlock(ctx context.Context, resetsAtUnix int64, rateLimitType string, observedAt time.Time) error {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+
+	payload := rateLimitBlockJSON{
+		BlockedUntilUnix: resetsAtUnix,
+		RateLimitType:    rateLimitType,
+		ObservedAtUnix:   observedAt.Unix(),
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal rate-limit block: %w", err)
+	}
+	return uc.appStateRepo.Set(ctx, &domain.AppState{
+		Key:       appStateKeyRateLimitBlock,
+		ValueJSON: string(b),
+		UpdatedAt: observedAt,
+	})
+}
+
+// SetLimits persists a runtime override of the configured caps. A value of 0
+// for either field means "fall back to the config-derived value".
+// Returns the resulting effective limits.
+func (uc *BudgetUseCase) SetLimits(ctx context.Context, dailyMax, weeklyMax int) (scheduler.BudgetLimits, error) {
+	if dailyMax < 0 || weeklyMax < 0 {
+		return scheduler.BudgetLimits{}, fmt.Errorf("limits must be >= 0")
+	}
+	if dailyMax > 0 && weeklyMax > 0 && dailyMax > weeklyMax {
+		return scheduler.BudgetLimits{}, fmt.Errorf("daily_max (%d) must be <= weekly_max (%d)", dailyMax, weeklyMax)
+	}
+
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+
+	payload := limitsOverrideJSON{DailyMax: dailyMax, WeeklyMax: weeklyMax}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return scheduler.BudgetLimits{}, fmt.Errorf("marshal limits override: %w", err)
+	}
+	if err := uc.appStateRepo.Set(ctx, &domain.AppState{
+		Key:       appStateKeyLimitsOverride,
+		ValueJSON: string(b),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		return scheduler.BudgetLimits{}, err
+	}
+
+	return uc.effectiveLimitsLocked(ctx)
+}
+
+// snapshotLocked must be called with uc.mu held.
+func (uc *BudgetUseCase) snapshotLocked(ctx context.Context, now time.Time) (BudgetSnapshot, error) {
+	limits, err := uc.effectiveLimitsLocked(ctx)
+	if err != nil {
+		return BudgetSnapshot{}, err
+	}
+	counters, err := uc.loadCountersLocked(ctx)
+	if err != nil {
+		return BudgetSnapshot{}, err
+	}
+	block, err := uc.loadBlockLocked(ctx)
+	if err != nil {
+		return BudgetSnapshot{}, err
+	}
+
+	rolled := scheduler.RolloverCounters(now, counters, limits)
+	if rolled != counters {
+		if err := uc.persistCountersLocked(ctx, rolled); err != nil {
+			return BudgetSnapshot{}, err
+		}
+		counters = rolled
+	}
+
+	reason := scheduler.EvaluateBudget(now, counters, limits, block)
+	return BudgetSnapshot{
+		Counters: counters,
+		Limits:   limits,
+		Block:    block,
+		Reason:   reason,
+	}, nil
+}
+
+func (uc *BudgetUseCase) effectiveLimitsLocked(ctx context.Context) (scheduler.BudgetLimits, error) {
+	limits := uc.configLimits
+
+	state, err := uc.appStateRepo.Get(ctx, appStateKeyLimitsOverride)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return limits, nil
+		}
+		return limits, err
+	}
+	var ov limitsOverrideJSON
+	if err := json.Unmarshal([]byte(state.ValueJSON), &ov); err != nil {
+		// Corrupt override — log? We just ignore it and use config.
+		return limits, nil
+	}
+	if ov.DailyMax > 0 {
+		limits.DailyMax = ov.DailyMax
+	}
+	if ov.WeeklyMax > 0 {
+		limits.WeeklyMax = ov.WeeklyMax
+	}
+	return limits, nil
+}
+
+func (uc *BudgetUseCase) loadCountersLocked(ctx context.Context) (scheduler.BudgetCounters, error) {
+	state, err := uc.appStateRepo.Get(ctx, appStateKeyTaskCounters)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return scheduler.BudgetCounters{}, nil
+		}
+		return scheduler.BudgetCounters{}, err
+	}
+	var c taskCountersJSON
+	if err := json.Unmarshal([]byte(state.ValueJSON), &c); err != nil {
+		return scheduler.BudgetCounters{}, nil
+	}
+	return scheduler.BudgetCounters{
+		DailyCount:  c.DailyCount,
+		DailyKey:    c.DailyKey,
+		WeeklyCount: c.WeeklyCount,
+		WeeklyKey:   c.WeeklyKey,
+	}, nil
+}
+
+func (uc *BudgetUseCase) persistCountersLocked(ctx context.Context, counters scheduler.BudgetCounters) error {
+	payload := taskCountersJSON{
+		DailyCount:  counters.DailyCount,
+		DailyKey:    counters.DailyKey,
+		WeeklyCount: counters.WeeklyCount,
+		WeeklyKey:   counters.WeeklyKey,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal counters: %w", err)
+	}
+	return uc.appStateRepo.Set(ctx, &domain.AppState{
+		Key:       appStateKeyTaskCounters,
+		ValueJSON: string(b),
+		UpdatedAt: time.Now(),
+	})
+}
+
+func (uc *BudgetUseCase) loadBlockLocked(ctx context.Context) (scheduler.RateLimitBlock, error) {
+	state, err := uc.appStateRepo.Get(ctx, appStateKeyRateLimitBlock)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return scheduler.RateLimitBlock{}, nil
+		}
+		return scheduler.RateLimitBlock{}, err
+	}
+	var b rateLimitBlockJSON
+	if err := json.Unmarshal([]byte(state.ValueJSON), &b); err != nil {
+		return scheduler.RateLimitBlock{}, nil
+	}
+	if b.BlockedUntilUnix == 0 {
+		return scheduler.RateLimitBlock{}, nil
+	}
+	return scheduler.RateLimitBlock{
+		BlockedUntil:  time.Unix(b.BlockedUntilUnix, 0),
+		RateLimitType: b.RateLimitType,
+	}, nil
+}

--- a/internal/usecase/budget_usecase_test.go
+++ b/internal/usecase/budget_usecase_test.go
@@ -1,0 +1,185 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gs97ahn/claude-ops/internal/scheduler"
+	"github.com/gs97ahn/claude-ops/internal/usecase"
+)
+
+func defaultLimits(t *testing.T) scheduler.BudgetLimits {
+	t.Helper()
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Fatalf("load tz: %v", err)
+	}
+	return scheduler.BudgetLimits{
+		DailyMax:     2,
+		WeeklyMax:    5,
+		WeekStartsOn: time.Monday,
+		ResetTZ:      loc,
+	}
+}
+
+func TestBudgetUseCase_FreshSnapshot_Allows(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+
+	snap, err := uc.Snapshot(context.Background(), now)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snap.Reason != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed, got %q", snap.Reason)
+	}
+	if snap.Counters.DailyCount != 0 || snap.Counters.WeeklyCount != 0 {
+		t.Errorf("expected fresh counters, got %+v", snap.Counters)
+	}
+}
+
+func TestBudgetUseCase_CheckAndIncrement_HitsDailyCap(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		reason, _, err := uc.CheckAndIncrement(ctx, now)
+		if err != nil {
+			t.Fatalf("inc %d: %v", i, err)
+		}
+		if reason != scheduler.BudgetReasonAllowed {
+			t.Fatalf("inc %d: expected allowed, got %q", i, reason)
+		}
+	}
+
+	reason, snap, err := uc.CheckAndIncrement(ctx, now)
+	if err != nil {
+		t.Fatalf("inc 3: %v", err)
+	}
+	if reason != scheduler.BudgetReasonDailyCap {
+		t.Errorf("expected daily_cap_reached, got %q", reason)
+	}
+	if snap.Counters.DailyCount != 2 {
+		t.Errorf("expected daily count 2 (not incremented), got %d", snap.Counters.DailyCount)
+	}
+}
+
+func TestBudgetUseCase_RolloverNextDay(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+	ctx := context.Background()
+
+	day1 := time.Date(2026, 4, 20, 23, 0, 0, 0, time.UTC) // Mon Seoul = Tue 08:00
+	for i := 0; i < 2; i++ {
+		if _, _, err := uc.CheckAndIncrement(ctx, day1); err != nil {
+			t.Fatalf("day1 inc %d: %v", i, err)
+		}
+	}
+	// Tomorrow same week — daily resets, weekly does not.
+	day2 := day1.Add(24 * time.Hour)
+	reason, snap, err := uc.CheckAndIncrement(ctx, day2)
+	if err != nil {
+		t.Fatalf("day2: %v", err)
+	}
+	if reason != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed after daily rollover, got %q", reason)
+	}
+	if snap.Counters.DailyCount != 1 {
+		t.Errorf("expected daily count 1 after rollover, got %d", snap.Counters.DailyCount)
+	}
+	if snap.Counters.WeeklyCount != 3 {
+		t.Errorf("expected weekly count 3 (preserved), got %d", snap.Counters.WeeklyCount)
+	}
+}
+
+func TestBudgetUseCase_WeeklyCap(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	limits := defaultLimits(t)
+	limits.DailyMax = 0 // unlimited daily
+	limits.WeeklyMax = 3
+	uc := usecase.NewBudgetUseCase(repo, limits)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		if _, _, err := uc.CheckAndIncrement(ctx, now); err != nil {
+			t.Fatalf("inc %d: %v", i, err)
+		}
+	}
+	reason, _, err := uc.CheckAndIncrement(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != scheduler.BudgetReasonWeeklyCap {
+		t.Errorf("expected weekly_cap_reached, got %q", reason)
+	}
+}
+
+func TestBudgetUseCase_RateLimitBlock_PreventsAndExpires(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	resetsAt := now.Add(2 * time.Hour)
+	if err := uc.RecordRateLimitBlock(ctx, resetsAt.Unix(), "five_hour", now); err != nil {
+		t.Fatalf("record block: %v", err)
+	}
+
+	reason, _, err := uc.CheckAndIncrement(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != scheduler.BudgetReasonRateLimited {
+		t.Errorf("expected rate_limited, got %q", reason)
+	}
+
+	// After the block expires, gate opens again.
+	later := resetsAt.Add(time.Minute)
+	reason, _, err = uc.CheckAndIncrement(ctx, later)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != scheduler.BudgetReasonAllowed {
+		t.Errorf("expected allowed after expiry, got %q", reason)
+	}
+}
+
+func TestBudgetUseCase_SetLimitsOverride(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+	ctx := context.Background()
+
+	eff, err := uc.SetLimits(ctx, 10, 20)
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if eff.DailyMax != 10 || eff.WeeklyMax != 20 {
+		t.Errorf("expected daily=10 weekly=20, got %+v", eff)
+	}
+
+	// Snapshot should pick up the override.
+	snap, err := uc.Snapshot(ctx, time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Limits.DailyMax != 10 || snap.Limits.WeeklyMax != 20 {
+		t.Errorf("snapshot did not pick up override: %+v", snap.Limits)
+	}
+}
+
+func TestBudgetUseCase_SetLimits_RejectsInvalid(t *testing.T) {
+	repo := &fakeAppStateRepo{}
+	uc := usecase.NewBudgetUseCase(repo, defaultLimits(t))
+
+	if _, err := uc.SetLimits(context.Background(), -1, 5); err == nil {
+		t.Error("expected error for negative daily")
+	}
+	if _, err := uc.SetLimits(context.Background(), 10, 5); err == nil {
+		t.Error("expected error for daily > weekly")
+	}
+}


### PR DESCRIPTION
## Summary
- 일일/주간 task 카운트 캡 + CLI `rate_limit_event` 기반 자동 throttle 으로 Claude 플랜 한도를 보호하는 budget gate 추가
- AppState 영속화 (`task_counters`, `rate_limit_block`, `limits_override`) — 재시작 후에도 카운터·블록 유지
- 항상 enforced (full mode 도 우회 불가)
- HTTP: `GET /modes/limits`, `PATCH /modes/limits` 으로 런타임 조회·조절

## Design
- Pure 도메인 (`internal/scheduler/budget_gate.go`): `EvaluateBudget`, `RolloverCounters`, `DateKey`, `WeekKey` — TZ 경계·주 시작 요일 고려, 0 = 무제한
- Persistence (`internal/usecase/budget_usecase.go`): `Snapshot`, `CheckAndIncrement` (원자적 게이트+증가), `RecordRateLimitBlock`, `SetLimits` — `sync.Mutex` 로 in-process 직렬화
- Scheduler tick: poll 후 `BudgetGate.SnapshotReason` — 차단 시 dispatch 스킵 (poll 은 계속)
- Worker: claude spawn 직전 `Budget.CheckAndIncrementReason` (트랜잭션), `*stream.ErrRateLimited` 잡아 `RecordRateLimitBlock` + `usage_warning` event
- Config: `limits.{daily_max_tasks, weekly_max_tasks, week_starts_on, reset_tz}` — 기본 daily=5, weekly=auto(35), Asia/Seoul · mon

## Why
PRD §12 OI-4 (full mode 종료 후 복귀 정책) 해소 — 별도 자동 해제·재시도 대신 단일 `blocked_until` 게이트로 통일. PRD §10 R6 (rate-limit 은 예측 불가, 첫 wall hit 1건 fail 불가피) 도 카운트 캡으로 완화. 자세한 PRD 변경은 `docs/specs/claude-ops.md` 참조.

## Test plan
- [x] `go test ./...` — 전 패키지 통과 (신규 테스트 8 케이스 + 7 케이스)
- [x] `go build ./...` 및 `go vet ./...` 클린
- [ ] 운영 환경에서 `GET /modes/limits` 200 OK 확인
- [ ] `PATCH /modes/limits {"daily_max":1}` 후 2번째 task spawn 시도가 cancel 되는지 확인
- [ ] rate_limit_event fixture 로 worker 재현 → `rate_limit_block` AppState 영속화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)