### PR TITLE
chore(deploy): add Docker deploy.sh for home-server rollout

### DIFF
--- a/deployments/deploy.sh
+++ b/deployments/deploy.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# -------------------------
+# 기본 설정
+# -------------------------
+APP_NAME="claude-ops"
+OUTER_PORT=8787
+INNER_PORT=8787
+IMAGE="ghcr.io/nogamsung/claude-ops:latest"
+
+ENV_FILE="/home/gs97ahn/app/env/claude-ops"
+CONFIG_FILE="/home/gs97ahn/app/claude-ops/config.yaml"
+DATA_DIR="/home/gs97ahn/app/claude-ops/data"
+WORKTREE_DIR="/home/gs97ahn/app/claude-ops/.worktrees"
+PROMPTS_DIR="/home/gs97ahn/app/claude-ops/prompts"
+LOG_DIR="/home/gs97ahn/app/claude-ops/logs"
+
+# Host 에 이미 'claude login' / 'gh auth login' 이 완료돼 있어야 함 (PRD §9).
+# 컨테이너는 agent 유저로 구동되지만 HOME 은 /root 로 고정되므로 /root 에 마운트.
+CLAUDE_SESSION_DIR="$HOME/.claude"
+GH_CONFIG_DIR="$HOME/.config/gh"
+GIT_CONFIG="$HOME/.gitconfig"
+CLAUDE_BIN="/usr/local/bin/claude"
+GH_BIN="/usr/local/bin/gh"
+
+# -------------------------
+# 이미지 pull (최신 latest 확보)
+# -------------------------
+sudo docker pull $IMAGE
+
+# -------------------------
+# 이전 컨테이너 종료
+# -------------------------
+sudo docker kill $APP_NAME
+sudo docker rm $APP_NAME
+
+# -------------------------
+# 새 컨테이너 실행
+# -------------------------
+# - HTTP 는 localhost 에만 바인딩 (Slack interactions 은 nginx/caddy 리버스 프록시로 노출)
+# - /config, /prompts, claude / gh 세션은 read-only
+# - /data, /worktrees, /logs 는 read-write (Claude 가 파일 수정)
+docker run -itd \
+    --name $APP_NAME \
+    --restart=always \
+    --env-file $ENV_FILE \
+    -p 127.0.0.1:$OUTER_PORT:$INNER_PORT \
+    -v $CONFIG_FILE:/config/config.yaml:ro \
+    -v $DATA_DIR:/data \
+    -v $WORKTREE_DIR:/worktrees \
+    -v $PROMPTS_DIR:/prompts:ro \
+    -v $LOG_DIR:/logs \
+    -v $CLAUDE_SESSION_DIR:/root/.claude:ro \
+    -v $GH_CONFIG_DIR:/root/.config/gh:ro \
+    -v $GIT_CONFIG:/root/.gitconfig:ro \
+    -v $CLAUDE_BIN:/usr/local/bin/claude:ro \
+    -v $GH_BIN:/usr/local/bin/gh:ro \
+    $IMAGE \
+    -config /config/config.yaml
+
+# -------------------------
+# 새 애플리케이션 로그 확인
+# -------------------------
+sudo docker logs -f $APP_NAME


### PR DESCRIPTION
## Summary

사용자가 제시한 Spring Boot 프로젝트 deploy 스크립트 포맷 (kill → rm → run → logs -f) 을 claude-ops 볼륨 세트에 맞춰 이식.

- `127.0.0.1:8787:8787` — Slack interactions 는 nginx/caddy 리버스 프록시로 노출 (PRD §9)
- Read-only: `/config`, `/prompts`, `/root/.claude`, `/root/.config/gh`, `/root/.gitconfig`, `claude`/`gh` 바이너리
- Read-write: `/data` (SQLite), `/worktrees` (git worktree), `/logs`
- `docker pull` 로 매 배포마다 `:latest` 최신화 후 교체

## Operator 전제 조건

- Host 에 `claude login` + `gh auth login` 완료
- `/home/gs97ahn/app/claude-ops/{data,.worktrees,prompts,logs}` 디렉토리 생성
- `/home/gs97ahn/app/env/claude-ops` 에 `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET` 설정
- `/home/gs97ahn/app/claude-ops/config.yaml` 배치

## Test plan

- [ ] 첫 배포: `docker kill`/`rm` 이 에러 출력 후에도 `docker run` 이 실행되는지 확인
- [ ] `curl http://127.0.0.1:8787/healthz` → 200
- [ ] `docker exec claude-ops claude --version` → host 의 claude 바이너리 인식
- [ ] `docker exec claude-ops gh auth status` → 인증 유효
- [ ] 재배포: 기존 컨테이너 교체 후 `/data/agent.db` 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)