### PR TITLE
ci(release): emit only vX.Y.Z + latest for release images

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,10 +73,6 @@ jobs:
             exit 1
           fi
           VERSION="${TAG#v}"
-          CORE="${VERSION%%-*}"
-          MAJOR="${CORE%%.*}"
-          REST="${CORE#*.}"
-          MINOR="${REST%%.*}"
           if [[ "$VERSION" == *-* ]]; then
             IS_PRERELEASE=true
           else
@@ -85,8 +81,6 @@ jobs:
           {
             echo "tag=$TAG"
             echo "version=$VERSION"
-            echo "major=$MAJOR"
-            echo "minor=$MINOR"
             echo "is_prerelease=$IS_PRERELEASE"
           } >> "$GITHUB_OUTPUT"
 
@@ -95,25 +89,19 @@ jobs:
           ref: ${{ steps.meta_vars.outputs.tag }}
 
       # ── Metadata ────────────────────────────────────────────────────────────
-      # GITHUB_TOKEN-created tags don't fire workflow triggers, so we emit the
-      # full semver tag set inline here instead of relying on docker/metadata
-      # semver parsing.
+      # Emit only `vX.Y.Z` + `latest` (stable releases). Re-running on an
+      # existing tag simply overwrites the manifest — that's intentional.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         env:
           TAG: ${{ steps.meta_vars.outputs.tag }}
           VERSION: ${{ steps.meta_vars.outputs.version }}
-          MAJOR: ${{ steps.meta_vars.outputs.major }}
-          MINOR: ${{ steps.meta_vars.outputs.minor }}
           IS_PRERELEASE: ${{ steps.meta_vars.outputs.is_prerelease }}
         with:
           images: ghcr.io/nogamsung/claude-ops
           tags: |
             type=raw,value=${{ env.TAG }}
-            type=raw,value=${{ env.VERSION }}
-            type=raw,value=${{ env.MAJOR }}.${{ env.MINOR }}
-            type=raw,value=${{ env.MAJOR }},enable=${{ env.MAJOR != '0' && env.IS_PRERELEASE == 'false' }}
             type=raw,value=latest,enable=${{ env.IS_PRERELEASE == 'false' }}
           labels: |
             org.opencontainers.image.title=claude-ops


### PR DESCRIPTION
## Summary

릴리스 이미지 태그 세트를 `vX.Y.Z` + `latest` 로 축소. 기존 `X.Y.Z`, `X.Y`, `X` 는 제거.

## Why

- 릴리스 1회당 GHCR 에 5개의 동일 manifest 가 쌓여 가독성 저하.
- 같은 태그 재발행 시 overwrite 되는 현재 동작은 의도한 복구 경로 (`workflow_dispatch` 로 재실행) 이므로 주석에 명시.

## Changes

- `tags:` 블록: `VERSION` / `MAJOR.MINOR` / `MAJOR` 라인 삭제
- `meta_vars` 단계에서 더 이상 쓰지 않는 `major` / `minor` 출력 제거

## After-merge cleanup

머지 후 GHCR 에 이미 존재하는 중복 태그 (`0.1.0`, `0.1`, `0.2.0`, `0.2`) 는 API 로 수동 삭제 예정. `v0.1.0`, `v0.2.0`, `latest`, `main`, `sha-*` 는 유지.

## Test plan

- [ ] 머지 후 `gh workflow run release-please.yml -f tag=v0.2.0` 으로 재실행 → GHCR 에 `v0.2.0` + `latest` 만 업데이트 되는지 확인
- [ ] 다음 `feat:`/`fix:` 머지로 release-please 가 새 버전 cut 할 때 동일 태그 세트로 publish 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)