### PR TITLE
feat(github): add webhook receiver for issue events

### DIFF
--- a/cmd/claude-ops/main.go
+++ b/cmd/claude-ops/main.go
@@ -222,13 +222,25 @@ func run() error {
 		Enqueuer: maintenanceUC,
 	})
 
+	// GitHub webhook handler — registered only when secret is configured.
+	var webhookH api.GitHubWebhookHandler
+	if env.GitHubWebhookSecret != "" {
+		webhookVerifier := igithub.NewWebhookVerifier(env.GitHubWebhookSecret)
+		dedupCtx, dedupCancel := context.WithCancel(context.Background())
+		defer dedupCancel()
+		dedupCache := igithub.NewMemDedupCache(dedupCtx, 5*time.Minute)
+		webhookH = igithub.NewWebhookHandler(webhookVerifier, dedupCache, taskUC, taskRepo, &cfg.GitHub)
+	} else {
+		slog.Warn("GITHUB_WEBHOOK_SECRET unset — /github/webhook endpoint will not be registered")
+	}
+
 	// HTTP server.
 	healthH := api.NewHealthHandler(modeUC)
 	taskH := api.NewTaskHandler(taskUC)
 	modeH := api.NewModeHandler(modeUC)
 	limitsH := api.NewLimitsHandler(budgetUC)
 	slackH := api.NewSlackHandler(env.SlackSigningSecret, sched)
-	router := api.NewRouter(healthH, taskH, modeH, limitsH, slackH)
+	router := api.NewRouter(healthH, taskH, modeH, limitsH, slackH, webhookH)
 	metrics.NewHandler(metricsRecorder).Register(router)
 
 	srv := &http.Server{

--- a/docs/specs/ci-fix-loop.md
+++ b/docs/specs/ci-fix-loop.md
@@ -1,0 +1,270 @@
+# PRD — ci-fix-loop
+
+| 항목 | 값 |
+|------|-----|
+| 작성일 | 2026-04-27 |
+| 상태 | draft |
+| 스택 범위 | Go (단일 바이너리, scheduled-dev-agent 의 후속 모듈) |
+| 우선순위 | P1 |
+| 작성자 | gs97ahn@gmail.com |
+| 모 PRD | [`./scheduled-dev-agent.md`](./scheduled-dev-agent.md) |
+
+---
+
+## 1. 배경
+
+`scheduled-dev-agent` 의 워커는 이슈 → PR 까지 자동화하지만 **PR 생성 직후 GitHub Actions CI 가 실패** 하면 사람이 직접 로그를 확인하고 후속 수정 커밋을 만들어야 한다. 활성 시간대 외(밤·새벽)에 PR 이 만들어졌다면 다음 윈도우까지 CI 실패는 방치되어, 본 시스템의 "사람 개입 0회" 목표(G1)가 깨진다.
+
+이 기능은 **PR 생성 직후 CI 결과를 polling 하다가 실패 conclusion 을 발견하면 같은 worktree·branch 에서 자동 후속 fix task 를 spawn 해 추가 커밋을 같은 PR 에 push** 하는 보정 루프를 추가한다. 무한 루프 방지를 위해 **retry cap (기본 2회)** 를 적용하며, 활성 시간대·budget gate·rate-limit block 등 모든 기존 게이트를 그대로 통과해야 한다.
+
+핵심 제약: GitHub webhook 은 별도 PRD(github-webhook) 에서 통합 예정이므로 **v1 은 polling 만**. CI 상태 조회는 `gh pr checks <pr_number> --json conclusion,name,detailsUrl` 로 통일.
+
+## 2. 목표 (Goals)
+
+- G1. CI failure 발견부터 fix task enqueue 까지 **2분 이내** (poll interval ≤ 60s 기준)
+- G2. 같은 PR 에 대해 fix attempt 가 **기본 max 2회** 까지만 시도되고 그 이상은 자동 escalate (Slack 통지 + 멈춤)
+- G3. 동일 PR + 동일 head commit SHA 조합으로 **fix task 는 정확히 0 또는 1개** 만 enqueue (중복 방지)
+- G4. fix task 도 active window / budget gate / rate-limit block 을 **그대로 enforced** — 야간에 자동 spawn 되지 않음
+- G5. fix 프롬프트에 **실패한 step 이름과 log tail (gh run view --log-failed)** 이 항상 포함되어 Claude 가 원인 식별 가능
+- G6. 기존 worker pipeline (markRunning → ... → createPR → markDone) 변경 최소화 — fix loop 는 별도 stage 로 부착
+
+## 3. 비목표 (Non-goals)
+
+- GitHub webhook (`workflow_run`, `check_run`) 수신 — 별도 PRD `github-webhook` 에서 다룸
+- CI 의 특정 step 단위 재실행 (`gh run rerun --failed`) 만으로 해결 시도 — Claude 호출 없이 인프라 재시도하는 경로는 v2
+- CI 실패 원인 자체 분류 / triage (테스트 vs 린트 vs 빌드) — Claude 가 로그를 보고 알아서 판단
+- max attempt 초과 시 자동 PR close — v1 은 stuck 상태로 남기고 Slack 알림만
+- 다른 PR (다른 task 가 만든) 의 CI 모니터링 — 본 task 가 만든 PR 만 추적
+- merge 자동화 — 사람 review 필수 원칙 유지
+
+## 4. 대상 사용자
+
+| 페르소나 | 역할 | 목표 |
+|----------|------|------|
+| Solo developer (P1) | 홈서버 운영자, scheduled-dev-agent 운영 중 | 수면·업무 시간 외에 만들어진 PR 의 CI 실패가 다음 윈도우까지 방치되지 않게 |
+| Small team lead (P2) | 보안/성능 자동 처리 운영자 | 자동 PR 의 CI 실패가 본인 업무 시간을 잠식하지 않게 |
+
+권한 모델: 모 PRD 와 동일 — 운영자 = `gh` CLI 인증 사용자.
+
+## 5. 유저 스토리
+
+| # | 스토리 | 수락 기준 |
+|---|--------|----------|
+| US-1 | 운영자로서 자동 PR 의 CI 가 실패하면 **사람 개입 없이 후속 fix 커밋이 같은 PR 에 추가** 되기를 원한다 | 1) PR 생성 후 워커가 `gh pr checks` 를 polling (default 60s) <br> 2) 모든 check 가 종료된 시점에 하나라도 `conclusion ∈ {failure, timed_out, cancelled, action_required}` 면 fix task 를 enqueue <br> 3) fix task 는 같은 worktree·branch 를 재사용 → 추가 커밋 → 같은 PR 에 push (PR 번호·URL 변경 없음) <br> 4) 모든 check 가 `success` 면 polling 종료 + Slack `:white_check_mark: CI passed` |
+| US-2 | 운영자로서 **무한 루프** 방지를 위해 fix attempt 횟수에 상한이 있기를 원한다 | 1) `Task.fix_attempt_count` 컬럼이 추가되어 fix task 마다 +1 <br> 2) `config.yaml` 의 `ci_fix.max_attempts` (default 2) 를 초과하면 새 fix task 를 enqueue 하지 않음 <br> 3) 한도 도달 시 Slack `:warning: CI fix exhausted (2/2 attempts)` + PR 코멘트 1줄 (`@user CI still failing after 2 auto-fix attempts`) <br> 4) 부모-자식 관계는 `parent_task_id` FK 로 추적 (체인 길이 검증 가능) |
+| US-3 | 운영자로서 fix Claude 가 **실패한 step 이름과 log tail** 을 보고 원인을 파악하기를 원한다 | 1) `gh run view <run_id> --log-failed --json` 으로 실패 step + log tail (최근 200줄) 추출 <br> 2) `prompts/ci-fix.tmpl` 에 `{{.FailedStep}}`, `{{.LogTail}}`, `{{.PRNumber}}`, `{{.PreviousAttempts}}` 바인딩 <br> 3) log tail 이 16KB 초과 시 끝부분 200줄로 절단 + `[truncated]` 마커 <br> 4) 시크릿 마스킹: `${{ secrets.* }}` 토큰 패턴은 `***` 로 치환 후 프롬프트 삽입 |
+| US-4 | 운영자로서 fix task 도 **활성 시간대·budget gate·rate-limit block** 을 그대로 통과해야 한다고 본다 | 1) fix task 는 status=queued 로 enqueue → 기존 scheduler tick 이 dispatch <br> 2) window 밖이면 다음 윈도우까지 대기 (즉시 실행 금지) <br> 3) daily/weekly cap 카운터에 fix task 도 1건으로 카운트 <br> 4) rate_limit_block 활성 중이면 dispatch 차단 — 모 PRD §6.2 동일 |
+| US-5 | 운영자로서 같은 PR + 같은 commit SHA 에 대해 **중복 fix task** 가 만들어지지 않기를 원한다 | 1) fix task 생성 전 `(parent_task_id, head_sha)` 유니크 검사 <br> 2) 이미 동일 키로 fix task 가 존재하면 스킵 (info log 만) <br> 3) head_sha 는 `gh pr view --json headRefOid` 로 조회 <br> 4) head_sha 가 새로 push 되어 바뀌면 attempt 카운터를 새로 사용 (다른 commit 대상이므로 별개) |
+| US-6 | 운영자로서 CI 결과 polling 상태를 **`/tasks/{id}` 로 조회** 하여 진행도를 알고 싶다 | 1) Task 상세에 `ci_status ∈ {pending, watching, passed, failed, exhausted}` 가 노출됨 <br> 2) TaskEvent 에 `ci_check_polled`, `ci_failure_detected`, `ci_fix_enqueued`, `ci_fix_exhausted` kind 추가 <br> 3) `GET /tasks?ci_status=watching` 필터 지원 <br> 4) Swagger 에 신규 enum 반영 |
+| US-7 | 운영자로서 fix 루프를 **글로벌 토글** 로 끌 수 있어야 한다 | 1) `config.yaml` 의 `ci_fix.enabled` (default true) 로 기능 자체 on/off <br> 2) 또는 `PATCH /modes/ci-fix {enabled: bool}` 로 런타임 토글 (AppState `ci_fix_mode` 영속) <br> 3) off 상태에서는 PR 생성 후 polling 도 시작하지 않음 (기존 워커 동작과 동일) |
+
+## 6. 핵심 플로우
+
+### 6.1 행복 경로 — CI 실패 → 자동 fix → 통과
+
+```
+1. 기존 worker 가 createPR 성공 → markDone
+2. (NEW) ci-watcher 가 task.pr_number, task.repo_full_name 으로 polling job 등록
+   - poll interval: 60s (config: ci_fix.poll_interval)
+   - poll timeout:  30m (config: ci_fix.poll_timeout) — 그 이상이면 timeout 처리
+3. tick 마다 `gh pr checks <pr> --json conclusion,name,detailsUrl,status` 호출
+4. 모든 check status == "completed" 가 될 때까지 대기 (in_progress / queued 는 계속 polling)
+5. 종료 후 conclusion 조사:
+   a) 모두 success → ci_status=passed, polling 종료, Slack 통지
+   b) failure 등 발견 → 6.1.1 분기
+   c) action_required (manual approval) → ci_status=stuck, polling 종료, Slack 통지
+```
+
+#### 6.1.1 fix task enqueue
+
+```
+6. PR head_sha 조회 → (parent_task_id, head_sha) 로 중복 검사
+7. fix_attempt_count 가 max_attempts 미만인지 확인
+8. gh run view <failed_run_id> --log-failed 로 로그 추출 (시크릿 마스킹)
+9. 새 Task INSERT:
+     - task_type = 'ci-fix'
+     - parent_task_id = 원본 task.id
+     - fix_attempt_count = 부모.fix_attempt_count + 1 (부모가 ci-fix 면 그 카운트 + 1)
+     - repo_full_name, issue_number = 부모와 동일
+     - worktree_path = 부모 worktree 재사용 (제거되지 않음 — 6.3 참조)
+     - prompt_template = "ci-fix"
+     - status = 'queued'
+10. TaskEvent kind='ci_fix_enqueued' 기록
+11. Slack 통지 (:gear: CI failed — fix attempt {n}/{max})
+12. scheduler tick 이 다음 윈도우 안에서 budget gate 통과 시 dispatch
+13. fix worker 가 워크트리 진입 → ci-fix.tmpl 렌더 (FailedStep, LogTail 포함)
+14. claude 실행 → commit → push (같은 branch) → PR 자동 업데이트 (gh pr create 호출 안 함)
+15. fix task 의 polling job 다시 등록 (재귀)
+```
+
+### 6.2 예외 경로
+
+- **PR 이 닫히거나 merge 됨**: polling 즉시 중단, ci_status=closed 로 마킹.
+- **gh CLI 인증 만료**: polling 실패 → 3회 재시도 후 task event `ci_check_polled` payload 에 err 기록 + Slack 1회 알림 (rate-limited per task).
+- **head_sha 변경 (사람 또는 다른 시스템이 직접 푸시)**: attempt 카운터 새로 시작 (별개 commit 으로 간주). 중복 검사 키도 새 sha 기준.
+- **max_attempts 도달**: ci_status=exhausted, polling 종료. Slack 통지 + (옵션) PR 코멘트. AppState 에 `ci_fix_exhausted_at` 시각 기록.
+- **poll_timeout 초과 (30m)**: ci_status=timeout, polling 종료. CI 가 실제로 끝났는지 한 번 더 확인 후 마킹. Slack 통지.
+- **active window 밖에서 fix task dispatch 시도**: scheduler 가 큐에 보관만 함. polling 은 백그라운드에서 계속 진행 (CI 끝났는지는 관찰).
+- **rate_limit_block 활성**: fix task dispatch 차단 (모 PRD §6.2 와 동일). reset 후 다음 tick 부터 dispatch.
+- **PR 생성 자체가 실패한 task**: ci-watcher 등록 안 됨 (pr_number == 0 가드).
+- **재시작 후 watching 중이던 task 복구**: AppState 의 `ci_watch_jobs` 또는 `tasks where ci_status='watching'` SELECT 후 polling 재개. 재시작 동안 누락된 CI 결과는 첫 tick 에 즉시 평가됨.
+
+### 6.3 worktree 수명 변경
+
+기존 워커는 `markDone` 직후 worktree 를 제거(`git worktree remove --force`)했다. fix loop 는 같은 worktree 에서 추가 커밋이 필요하므로:
+
+- ci-fix 가 enabled 인 task 는 markDone 시점에 worktree 를 **보존**
+- 다음 중 하나가 발생하면 cleanup:
+  - ci_status=passed
+  - ci_status=exhausted / timeout / closed / stuck
+  - polling 자체가 비활성화됨
+- 정기 청소: scheduler tick 시 ci_status ∈ {passed, exhausted, ...} 이고 cleanup 안 된 worktree 가 있으면 일괄 제거 (orphan 방어)
+
+## 7. 데이터 모델 (요약)
+
+기존 SQLite (`data/agent.db`) 에 컬럼·테이블 확장. 새 migration 두 개 추가 (기존 migration 수정 금지).
+
+```
+Task (변경)
+  + parent_task_id        TEXT    NULL (FK → tasks.id, ON DELETE SET NULL)
+  + fix_attempt_count     INTEGER NOT NULL DEFAULT 0
+  + ci_status             TEXT    NOT NULL DEFAULT '' CHECK(ci_status IN
+                           ('', 'pending', 'watching', 'passed', 'failed',
+                            'exhausted', 'timeout', 'stuck', 'closed'))
+  + head_sha              TEXT    NOT NULL DEFAULT ''
+  + ci_last_polled_at     DATETIME NULL
+
+  task_type CHECK 확장: ('feature', 'security', 'perf', 'ci-fix')
+
+Index (신규)
+  idx_tasks_parent          ON tasks(parent_task_id)
+  idx_tasks_ci_status       ON tasks(ci_status)
+  uniq_tasks_parent_headsha ON tasks(parent_task_id, head_sha) WHERE task_type = 'ci-fix'
+                              (SQLite partial index — 중복 방지 원자성)
+
+TaskEvent.kind 확장
+  + ci_check_polled         payload: {run_ids, summary, status_per_check}
+  + ci_failure_detected     payload: {failed_step, run_id, conclusion, head_sha}
+  + ci_fix_enqueued         payload: {child_task_id, attempt, max_attempts}
+  + ci_fix_exhausted        payload: {attempts}
+
+AppState (신규 키)
+  ci_fix_mode      value: {enabled: bool, updated_at}
+  ci_watch_jobs    value: {tasks: [{task_id, pr_number, repo, next_poll_at_unix}]}
+                    (재시작 후 polling 복구용 — DB SELECT 로 대체 가능. 우선 후자.)
+```
+
+`Task 1 ── N Task` (parent ↔ child fix-chain). 체인 길이는 `fix_attempt_count` 와 일치.
+
+## 8. API 계약 (요약)
+
+신규/변경 엔드포인트만:
+
+```
+GET    /tasks?status=&ci_status=&limit=&cursor=     ci_status 필터 추가
+GET    /tasks/{id}                                  응답에 ci_status, head_sha,
+                                                    fix_attempt_count, parent_task_id 추가
+GET    /modes/ci-fix                                {enabled: bool}
+PATCH  /modes/ci-fix                                {enabled: bool}
+```
+
+**Response DTO 변경 (`internal/api/dto.go` TaskResponse 확장):**
+
+```jsonc
+{
+  "id": "...",
+  "repo_full_name": "owner/repo",
+  "issue_number": 42,
+  "task_type": "ci-fix",            // 신규 enum 값
+  "status": "queued",
+  "ci_status": "watching",          // NEW
+  "parent_task_id": "abc-123",      // NEW (nullable)
+  "fix_attempt_count": 1,           // NEW
+  "head_sha": "f00ba2...",          // NEW
+  "ci_last_polled_at": "2026-04-27T10:00:00Z"  // NEW
+}
+```
+
+## 9. 비기능 요구사항
+
+| 항목 | 요구 |
+|------|------|
+| polling 성능 | tick 당 `gh` 호출은 `watching` 상태 task 수에 비례. v1 은 직렬 1개 제한이라 사실상 1회/tick |
+| 보안 | log tail 의 secret 패턴 마스킹: `(?i)(token|secret|password|api[_-]?key)\s*[:=]\s*\S+` 및 `${{ secrets.* }}` |
+| 신뢰성 | 재시작 후 `watching` task 의 polling 5초 내 재개 |
+| 활성시간 게이트 | fix task dispatch 는 모 PRD 의 budget gate / window gate 통과 필수. polling 자체는 게이트 무관 (gh CLI 호출만) |
+| 관측성 | ci_status 변화마다 TaskEvent 1건. polling tick 은 `slog.Debug` |
+| 테스트 커버리지 | 80% (게이트). `internal/ci` 패키지는 **85% 이상** |
+| 호환성 | 기존 task (ci_status='') 는 polling 미적용 — 마이그레이션은 컬럼 추가만, 기존 row 영향 없음 |
+
+## 10. 의존성 / 리스크
+
+**의존성**
+
+- `gh` CLI 의 `pr checks --json` / `run view --log-failed` 안정성 (모 PRD 와 동일 의존)
+- 기존 `internal/scheduler.Worker` 의 markDone 단계 hook 추가 가능성
+- 기존 `internal/github.PRCreator` 의 worktree 보존 옵션 (현재는 무조건 정리 안 됨 — worker 가 정리)
+
+**리스크**
+
+- **R1 (Med)**: GitHub CI 가 일시적으로 `failure` 보고 후 retry 로 `success` 복구 — fix task 가 불필요하게 spawn. 완화: 모든 check 가 `status=completed` 가 된 뒤에만 평가. 운영자가 `gh run rerun` 한 경우는 head_sha 동일하므로 중복 검사가 막아줌.
+- **R2 (Med)**: log tail 에 시크릿 누출 위험 → Claude 프롬프트로 흘러감. 완화: 패턴 기반 마스킹 + 단위 테스트 다량 + log tail 200줄 cap.
+- **R3 (Low)**: 부모 task 가 cancelled / failed 인데 PR 만 만들어졌다면? — 현재 워커는 createPR 실패 시 fail 이므로 PR 이 없어 polling 등록 안 됨. createPR 성공 후 markDone 직전에 죽으면 orphan 가능 — 재시작 시 `pr_url != '' AND ci_status = ''` 인 task 를 일괄 watching 으로 승격.
+- **R4 (Low)**: 같은 PR 에 사람이 직접 push (force-push 포함) → head_sha 가 바뀌면서 attempt 카운터 리셋. 의도된 동작이지만 무한 루프 가능성 미세하게 존재. 완화: 사람-author push (`gh pr view --json commits` 의 author 가 bot 이 아닌 경우) 는 watching 중단.
+- **R5 (Med)**: ci-fix Claude 가 실패 원인을 못 찾아 동일 변경을 반복 → 2회 모두 같은 패턴으로 fail. 완화: ci-fix 프롬프트에 `PreviousAttempts` 변수로 직전 시도 요약을 포함시켜 차이를 강제. 완전 해결은 아님 → max_attempts=2 가 안전판.
+
+## 11. 범위 외 (Out of Scope)
+
+- GitHub webhook 기반 즉시 트리거 (별도 PRD `github-webhook`)
+- CI 자체 재실행만으로 해결 (`gh run rerun --failed`) — Claude 호출 없는 경로는 v2
+- merge queue / auto-merge 통합
+- fix attempt 별 diff 비교 / 자동 squash
+- 다중 PR 동시 polling (v1 직렬 1 task 제한 그대로)
+
+## 12. 오픈 이슈
+
+- [ ] **OI-1**: log tail 의 시크릿 마스킹 패턴이 충분한가? `gh run view --log-failed` 출력에 secret 이 포함되는 케이스 (예: 환경변수 echo) 의 실측 샘플 확보 필요.
+- [ ] **OI-2**: `gh pr view --json commits[].author` 로 사람 push 감지가 안정적인가? GitHub bot account (Dependabot, Renovate) 와 본 시스템 (GitHub Actions context 의 `github-actions[bot]` 또는 운영자 PAT) 구분 룰 확정 필요.
+- [ ] **OI-3**: max_attempts 도달 시 PR 코멘트 자동 작성 여부 (US-2 수락기준 3 의 옵션). 코멘트 spam 우려 vs 사람 알림 필요성. 기본은 **작성** 으로 두되 config 토글 (`ci_fix.comment_on_exhaustion`) 제공 검토.
+- [ ] **OI-4**: polling 을 별도 goroutine pool 로 둘 것인가, 아니면 scheduler tick 안에 inline 으로 둘 것인가? 동시 직렬 1 task 제약이라 inline 이 단순. 단, watching task 가 누적되면 (사람이 PR 닫지 않은 경우) 큰 부하 가능성 — 일정 cap 필요할 수 있음.
+- [ ] **OI-5**: ci-fix.tmpl 의 정확한 텍스트 — Claude 에게 "직전 변경을 무효화하지 말고 추가 fix 만 적용" 임을 어떻게 강제할지. 모 PRD 의 OI-7 prompt 정책 (외부 네트워크 금지 / push 금지 / `CHANGES:` 섹션 출력) 와 일관되게 작성 필요.
+
+---
+
+## 참고 — 영향받는 패키지 (Go)
+
+```
+internal/
+  ci/              # NEW — CIWatcher, gh-checks 파서, log-tail 추출, secret 마스킹
+  ci/stream/       # NEW (옵션) — gh pr checks JSON 파서 분리
+  scheduler/       # MOD — Worker.markDone 후 ci-watcher hook, scheduler tick 에 polling
+  domain/          # MOD — Task 컬럼 추가, EventKind 추가, TaskType=ci-fix
+  repository/      # MOD — sqlc 쿼리 추가 (ListWatching, FindByParentAndHeadSHA)
+  usecase/         # MOD — TaskUseCase 에 EnqueueFixTask, ListByCIStatus
+  api/             # MOD — TaskResponse 확장, /modes/ci-fix 핸들러
+  config/          # MOD — CIFixConfig 추가 (enabled, max_attempts, poll_interval, poll_timeout, comment_on_exhaustion)
+  github/          # MOD — Client 에 GhPRChecks, GhRunLog, GhPRView, GhPRComment 추가
+
+migrations/
+  000004_add_ci_fix_columns_to_tasks.up.sql / .down.sql
+  (필요시) 000005_extend_task_type_check.up.sql / .down.sql
+
+db/query/
+  task.sql 에 sqlc 쿼리 추가:
+    - GetWatchingTasks
+    - FindFixChildByParentAndHeadSHA
+    - UpdateCIStatus
+
+prompts/
+  ci-fix.tmpl    # NEW
+
+config.example.yaml
+  ci_fix:
+    enabled: true
+    max_attempts: 2
+    poll_interval: "60s"
+    poll_timeout: "30m"
+    comment_on_exhaustion: true
+```
+
+단일 스택 프로젝트이므로 역할별 분할 없이 **단일 Go 구현 프롬프트** ([`./ci-fix-loop/go.md`](./ci-fix-loop/go.md)) 로 전달합니다.

--- a/docs/specs/ci-fix-loop/go.md
+++ b/docs/specs/ci-fix-loop/go.md
@@ -1,0 +1,387 @@
+# ci-fix-loop — Go 구현 가이드
+
+상위 PRD: [`../ci-fix-loop.md`](../ci-fix-loop.md)
+
+> 이 문서는 PRD 의 결정·근거를 반복하지 않습니다. 단계·체크리스트·수락 기준만 담습니다. 모순 시 PRD 가 우선.
+
+---
+
+## 0. 사전 확인
+
+### CLAUDE.md 핵심 규칙
+- DI 생성자 주입 / 전역 db 금지
+- 모든 레이어 `ctx context.Context` 첫 인자, 핸들러는 `c.Request.Context()`
+- `domain/` 외부 패키지 import 금지
+- 동적·집계·페이징 쿼리는 sqlc 필수 (raw SQL 하드코딩 금지) — 본 기능에서 `ListWatching`, `FindFixChildByParentAndHeadSHA`, `UpdateCIStatus` 모두 sqlc
+- 모든 신규 핸들러 swag godoc 필수
+- 기존 migration 수정 금지 — `000004_*` / 필요 시 `000005_*` 신규 추가만
+- 테스트 없이 UseCase 메서드 추가 금지
+- 로그에 secret 노출 금지 — `gh run view --log-failed` 출력에 secret 패턴 마스킹 필수
+- 커버리지 ≥80% (`internal/ci` 패키지는 ≥85%)
+
+### 영향받는 기존 파일 (수정)
+- `internal/domain/task.go` — Task 구조체에 `ParentTaskID`, `FixAttemptCount`, `CIStatus`, `HeadSHA`, `CILastPolledAt` 5개 필드 + `TaskTypeCIFix` 상수
+- `internal/domain/event.go` — `EventKindCICheckPolled` / `CIFailureDetected` / `CIFixEnqueued` / `CIFixExhausted` 4개 상수
+- `internal/domain/repository.go` — `TaskRepository` 인터페이스에 `ListWatching(ctx) ([]*Task, error)`, `FindFixChildByParentAndHeadSHA(ctx, parentID, sha)`, `UpdateCIStatus(ctx, taskID, status, lastPolledAt, headSHA)` 추가
+- `internal/repository/task_repository.go` — GORM struct (`gormTask`) 컬럼 매핑, sqlc 생성 쿼리 호출 위임
+- `internal/scheduler/worker.go` — `markDone` 직후 ci-watcher hook (PR 번호 존재 시 ci_status='watching' 으로 전이, worktree 보존), worktree cleanup 분기
+- `internal/scheduler/budget_gate.go` — fix task 도 daily/weekly cap 카운트 (변경 없을 가능성 — 모든 task 이미 카운트면 회귀 검증만)
+- `internal/api/dto.go` — `TaskResponse` 에 `ci_status`, `parent_task_id`, `fix_attempt_count`, `head_sha`, `ci_last_polled_at` 5개 필드 추가
+- `internal/api/handler.go` (또는 task_handler.go) — `GET /tasks?ci_status=` 필터 파싱
+- `internal/api/server.go` — `/modes/ci-fix` 라우트 등록
+- `internal/config/config.go` — `CIFix CIFixConfig` 추가 (`Enabled`, `MaxAttempts`, `PollInterval`, `PollTimeout`, `CommentOnExhaustion`)
+- `internal/config/validate.go` — CIFixConfig 검증 (`MaxAttempts >= 1`, interval > 0)
+- `internal/github/client.go` — `GhPRChecks(ctx, repo, prNumber)`, `GhRunLogFailed(ctx, runID)`, `GhPRView(ctx, repo, pr)`, `GhPRComment(ctx, repo, pr, body)` 메서드 추가
+- `cmd/scheduled-dev-agent/main.go` — DI 조립
+- `config.example.yaml` — `ci_fix:` 블록 추가
+
+### 신규 생성 파일
+- `migrations/000004_add_ci_fix_columns_to_tasks.up.sql`
+- `migrations/000004_add_ci_fix_columns_to_tasks.down.sql`
+- (필요 시) `migrations/000005_extend_task_type_check.up.sql` — SQLite CHECK 제약 변경 위해 표 재생성 필요한 경우 (단순 ALTER 로 안 되면 분리 마이그레이션)
+- `db/query/task_ci.sql` — sqlc 쿼리 (`ListWatching`, `FindFixChildByParentAndHeadSHA`, `UpdateCIStatus`) → `db/sqlc/` 자동 생성
+- `internal/ci/watcher.go` — `CIWatcher` (Tick · gh pr checks polling 오케스트레이션)
+- `internal/ci/checks.go` — `gh pr checks --json` 파싱 + conclusion 평가 (`AllSuccess`, `AnyFailure`, `AnyActionRequired`)
+- `internal/ci/log_extractor.go` — `gh run view --log-failed` 추출 + tail 200줄 cap
+- `internal/ci/secret_mask.go` — secret 패턴 마스킹 (regex)
+- `internal/ci/prompt_builder.go` — `prompts/ci-fix.tmpl` 렌더 (FailedStep, LogTail, PRNumber, PreviousAttempts)
+- `internal/api/mode_ci_fix_handler.go` — `GET/PATCH /modes/ci-fix`
+- `internal/usecase/ci_fix_usecase.go` — `EnqueueFixTask`, `ListByCIStatus`, `MarkCIPassed/Failed/Exhausted`
+- `prompts/ci-fix.tmpl`
+- 테스트: `internal/ci/*_test.go`, `internal/scheduler/worker_ci_test.go`, `internal/api/mode_ci_fix_handler_test.go`
+
+---
+
+## 1. 단계별 작업
+
+### Step 1 — Migration
+
+**파일**: `migrations/000004_add_ci_fix_columns_to_tasks.up.sql`
+```sql
+ALTER TABLE tasks ADD COLUMN parent_task_id    TEXT REFERENCES tasks(id) ON DELETE SET NULL;
+ALTER TABLE tasks ADD COLUMN fix_attempt_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN ci_status         TEXT    NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN head_sha          TEXT    NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN ci_last_polled_at DATETIME;
+
+CREATE INDEX idx_tasks_parent      ON tasks(parent_task_id);
+CREATE INDEX idx_tasks_ci_status   ON tasks(ci_status);
+CREATE UNIQUE INDEX uniq_tasks_parent_headsha
+    ON tasks(parent_task_id, head_sha)
+    WHERE task_type = 'ci-fix';
+```
+
+`000004_*.down.sql`:
+```sql
+DROP INDEX IF EXISTS uniq_tasks_parent_headsha;
+DROP INDEX IF EXISTS idx_tasks_ci_status;
+DROP INDEX IF EXISTS idx_tasks_parent;
+ALTER TABLE tasks DROP COLUMN ci_last_polled_at;
+ALTER TABLE tasks DROP COLUMN head_sha;
+ALTER TABLE tasks DROP COLUMN ci_status;
+ALTER TABLE tasks DROP COLUMN fix_attempt_count;
+ALTER TABLE tasks DROP COLUMN parent_task_id;
+```
+
+**task_type CHECK 확장 (`'ci-fix'` 추가)**: SQLite 의 CHECK 제약은 ALTER 가 안 되므로 **테이블 재생성** 이 필요할 수 있음. 우선 기존 `000001_create_tasks_table.up.sql` 의 task_type CHECK 가 어떻게 정의되어 있는지 확인:
+- enum CHECK 가 있다면 → `000005_extend_task_type_check.{up,down}.sql` 로 표 rebuild (`CREATE TABLE tasks_new` → `INSERT SELECT` → `DROP tasks` → `ALTER RENAME`). PRD §10 "기존 migration 수정 금지" 준수
+- enum CHECK 가 없다면 (자유 TEXT) → 000005 불필요
+
+**수락 기준**
+- `golang-migrate` 로 up/down 정상 적용 (테스트: `make migrate-test` 또는 sqlite 임시 파일)
+- 기존 task row 들의 `ci_status=''` 로 초기화되어 polling 영향 없음 (US-7)
+- 동일 (parent_task_id, head_sha) 두 번 INSERT 시 UNIQUE 위반 (PRD §7 마지막 줄)
+
+**Sub-agent**: `go-generator`
+
+### Step 2 — Domain
+
+**작업 내용**
+1. `internal/domain/task.go`:
+   ```go
+   type Task struct {
+       // ... 기존 ...
+       ParentTaskID     *string
+       FixAttemptCount  int
+       CIStatus         CIStatus  // 신규 타입
+       HeadSHA          string
+       CILastPolledAt   *time.Time
+   }
+
+   type CIStatus string
+   const (
+       CIStatusEmpty      CIStatus = ""
+       CIStatusPending    CIStatus = "pending"
+       CIStatusWatching   CIStatus = "watching"
+       CIStatusPassed     CIStatus = "passed"
+       CIStatusFailed     CIStatus = "failed"
+       CIStatusExhausted  CIStatus = "exhausted"
+       CIStatusTimeout    CIStatus = "timeout"
+       CIStatusStuck      CIStatus = "stuck"
+       CIStatusClosed     CIStatus = "closed"
+   )
+
+   const TaskTypeCIFix TaskType = "ci-fix"
+   ```
+2. `internal/domain/event.go` — 4개 EventKind 상수 추가
+3. `internal/domain/repository.go` — `TaskRepository` 에 3개 메서드 추가
+4. `internal/domain/error.go` — `ErrFixChildAlreadyExists`, `ErrCIFixExhausted` sentinel error (필요 시)
+
+**수락 기준**
+- `go vet ./internal/domain/...` 통과
+- domain 패키지가 gorm/gh CLI/외부 패키지 import 안 함 (CLAUDE.md NEVER)
+- 모든 신규 enum 값에 대한 `String()` 또는 직접 비교 가능
+
+**Sub-agent**: `go-modifier`
+
+### Step 3 — Repository (GORM + sqlc)
+
+**작업 내용**
+1. `internal/repository/task_repository.go` 의 `gormTask` 에 5개 컬럼 매핑 추가 (struct tag `gorm:"column:..."`)
+2. `db/query/task_ci.sql`:
+   ```sql
+   -- name: ListWatchingTasks :many
+   SELECT * FROM tasks WHERE ci_status = 'watching' ORDER BY ci_last_polled_at NULLS FIRST;
+
+   -- name: FindFixChildByParentAndHeadSHA :one
+   SELECT * FROM tasks
+   WHERE task_type = 'ci-fix' AND parent_task_id = ? AND head_sha = ?
+   LIMIT 1;
+
+   -- name: UpdateCIStatus :exec
+   UPDATE tasks SET ci_status = ?, ci_last_polled_at = ?, head_sha = ? WHERE id = ?;
+   ```
+3. `sqlc generate` 실행 — `db/sqlc/` 자동 갱신 (수동 수정 금지)
+4. Repository 구현체에서 sqlc 생성 함수 호출 → domain Task 매핑
+
+**수락 기준**
+- `sqlc generate` 무에러
+- Repository 통합 테스트 (sqlite 임시 DB) 4개 케이스 모두 통과:
+  - watching task 0건 → 빈 슬라이스
+  - watching task 2건 → ci_last_polled_at NULL 우선 정렬
+  - FindFixChild 동일 (parent, sha) 존재 → row 반환, 없으면 `ErrNotFound`
+  - UpdateCIStatus 후 SELECT 시 컬럼 일치
+- 커버리지 ≥ 85% (`internal/repository/`)
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 4 — UseCase
+
+**작업 내용**
+1. `internal/usecase/ci_fix_usecase.go`:
+   ```go
+   type CIFixUseCase interface {
+       EnqueueFixTask(ctx, parentTaskID, headSHA, failedStep, logTail string) (*domain.Task, error)
+       ListWatching(ctx) ([]*domain.Task, error)
+       MarkCIStatus(ctx, taskID, status, headSHA) error
+       IsExhausted(ctx, parentTaskID) (bool, error)  // fix_attempt_count >= max_attempts
+   }
+   ```
+2. `EnqueueFixTask`:
+   - `IsExhausted` true → `ErrCIFixExhausted` 반환 (호출자가 Slack `:warning:` 발송 + (옵션) PR 코멘트)
+   - `FindFixChildByParentAndHeadSHA` hit → 기존 child 반환 (no-op, 멱등)
+   - 부모 fetch → `attempt = parent.FixAttemptCount + 1` (부모가 ci-fix 면 그대로 +1, 아니면 1)
+   - INSERT 새 Task (`task_type=ci-fix`, `parent_task_id`, `fix_attempt_count=attempt`, `head_sha`, `status=queued`, `ci_status=''`)
+   - TaskEvent `kind=ci_fix_enqueued` 1건
+3. `MarkCIStatus`:
+   - status enum 검증
+   - UpdateCIStatus 호출 + TaskEvent 기록 (kind 자동 매핑: passed→ci_check_polled+passed, failed→ci_failure_detected, exhausted→ci_fix_exhausted)
+4. `internal/usecase/task_usecase.go` 의 `ListTasks` 에 `ci_status` 필터 추가 (`GET /tasks?ci_status=watching`)
+
+**수락 기준**
+- mockery 로 `TaskRepository` mock 후 단위 테스트:
+  - 정상 enqueue → 1건 INSERT, 1건 EventKind=ci_fix_enqueued
+  - 중복 (FindFixChild hit) → 기존 child 반환, INSERT 0건
+  - 한도 도달 → `ErrCIFixExhausted` + 1건 EventKind=ci_fix_exhausted
+- 동일 head_sha 변경 시 attempt 카운터가 새로 시작 (별개 row)
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 5 — CIWatcher (`internal/ci`)
+
+**작업 내용**
+1. `internal/ci/watcher.go`:
+   - `type Watcher struct { gh GitHubClient; uc CIFixUseCase; cfg CIFixConfig; clock Clock; slack SlackNotifier }`
+   - `Tick(ctx)` — `ListWatching()` → 각 task 에 대해:
+     - `gh pr view <pr> --json state,headRefOid,commits.author` 호출
+     - PR closed/merged → `MarkCIStatus(closed)` + worktree cleanup 신호
+     - last human push 감지 (`commits[-1].author != bot`) → US-2 R4 — watching 중단
+     - `gh pr checks <pr> --json conclusion,name,detailsUrl,status` 호출
+     - 모두 `status=completed` 가 아니면 다음 tick 까지 대기 (no-op + Debug 로그)
+     - 모두 success → `MarkCIStatus(passed)` + Slack `:white_check_mark:`
+     - any failure → `gh run view <id> --log-failed` 추출 → secret mask → `EnqueueFixTask`
+       - `ErrCIFixExhausted` → `MarkCIStatus(exhausted)` + Slack `:warning:` + (옵션) PR 코멘트
+       - 정상 → `MarkCIStatus(failed)` (자식 task 가 새 watching 시작은 다음 사이클)
+   - poll_timeout 초과 (`now - first_polled_at > 30m`) → `MarkCIStatus(timeout)`
+2. `internal/ci/checks.go` — `gh pr checks --json` 출력 → `[]CheckRun`, `func (c CheckSet) Status() ConclusionVerdict { allSuccess | anyFailure | anyActionRequired | inProgress }`
+3. `internal/ci/log_extractor.go` — `gh run view <id> --log-failed` stdout 캡처, 16KB cap, 끝 200줄, `[truncated]` 마커
+4. `internal/ci/secret_mask.go`:
+   - regex: `(?i)(token|secret|password|api[_-]?key)\s*[:=]\s*\S+` → group1 + `=***`
+   - `\$\{\{\s*secrets\.[A-Z0-9_]+\s*\}\}` → `***`
+   - 단위 테스트: 12+ 케이스 (실측 GitHub Actions 로그 fixture 포함)
+5. `internal/ci/prompt_builder.go` — `prompts/ci-fix.tmpl` 렌더 (`FailedStep`, `LogTail`, `PRNumber`, `PreviousAttempts`, `BasePrompt`)
+
+**Scheduler 통합** (`internal/scheduler/scheduler.go` 또는 `worker.go`):
+- 기존 tick loop 안에 `if cfg.CIFix.Enabled { ciWatcher.Tick(ctx) }` 호출 (직렬, inline — OI-4 결정 v1)
+- `Worker.markDone` 완료 후 PR 번호 존재 시 `MarkCIStatus(watching)` + worktree 보존
+- `MarkCIStatus(passed/exhausted/timeout/stuck/closed)` 호출 시 worktree cleanup 트리거 (orphan 방어)
+
+**수락 기준**
+- mockery `GitHubClient` 로 다음 시나리오 테이블 테스트:
+  - all success → passed
+  - 1 failure → fix enqueued (`EnqueueFixTask` 호출 1회, with masked log)
+  - in_progress 혼재 → no-op (`MarkCIStatus` 호출 0회)
+  - max_attempts 도달 후 failure → exhausted
+  - PR closed → closed
+  - poll_timeout 초과 → timeout
+  - human push 감지 → watching 중단 (status='' 로 복귀 또는 closed 마킹 결정 — PRD §10 R4 따라 `closed` 권장)
+- secret mask 테스트 12+ 케이스 통과
+- log tail 16KB 초과 시 정확히 200줄로 자르고 `[truncated]` 마커 포함
+- 커버리지 ≥ 85% (`internal/ci/`)
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 6 — Handler (Gin + swag godoc)
+
+**작업 내용**
+1. `internal/api/mode_ci_fix_handler.go`:
+   ```go
+   // GetCIFixMode reports the current ci-fix mode.
+   // @Summary Get ci-fix mode
+   // @Tags    modes
+   // @Success 200 {object} api.ModeResponse
+   // @Router  /modes/ci-fix [get]
+
+   // PatchCIFixMode toggles ci-fix mode at runtime.
+   // @Summary Toggle ci-fix mode
+   // @Tags    modes
+   // @Accept  json
+   // @Param   body body api.ModeToggleRequest true "..."
+   // @Success 200 {object} api.ModeResponse
+   // @Failure 400 {object} api.ErrorResponse
+   // @Router  /modes/ci-fix [patch]
+   ```
+   - AppState 키 `ci_fix_mode` 영속 (`{enabled: bool, updated_at}`)
+2. `internal/api/task_handler.go` (또는 동등) `ListTasks` 에 `ci_status` query param 파싱 추가, `TaskResponse` DTO 에 5개 신규 필드 매핑
+3. `internal/api/dto.go`:
+   ```go
+   type TaskResponse struct {
+       // ... 기존 ...
+       CIStatus         string  `json:"ci_status" example:"watching"`
+       ParentTaskID     *string `json:"parent_task_id,omitempty" example:"abc-123"`
+       FixAttemptCount  int     `json:"fix_attempt_count" example:"1"`
+       HeadSHA          string  `json:"head_sha" example:"f00ba2"`
+       CILastPolledAt   *string `json:"ci_last_polled_at,omitempty" example:"2026-04-27T10:00:00Z"`
+   }
+   ```
+
+**수락 기준**
+- httptest:
+  - `GET /tasks?ci_status=watching` → ci_status='watching' task 만 반환
+  - `GET /modes/ci-fix` → `{enabled:true}` (기본)
+  - `PATCH /modes/ci-fix {enabled:false}` → 200, AppState 갱신, 후속 GET 결과 일치
+- swag 재생성 후 `/swagger/index.html` 에 신규 라우트 + enum 노출
+- 커버리지 ≥ 85% (handler)
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 7 — DI 조립 (`cmd/scheduled-dev-agent/main.go`)
+
+**작업 내용**
+- `cifg := cfg.CIFix`
+- `ciFixUC := usecase.NewCIFixUseCase(taskRepo, eventRepo, cifg)`
+- `ciWatcher := ci.NewWatcher(ghClient, ciFixUC, cifg, slackClient, clock)`
+- scheduler 에 `ciWatcher` 주입 → tick loop 에서 호출
+- API handler 에 `ciFixUC` 주입
+- AppState repo 에 `ci_fix_mode` 키 초기화 (없으면 `{enabled: cifg.Enabled}` 로 seed)
+
+**수락 기준**
+- `go build ./...`, `go test ./cmd/...` 통과
+- ci_fix.enabled=false 부팅 → watcher tick 자체 스킵 (`slog.Debug("ci-fix disabled")`)
+
+**Sub-agent**: `go-modifier`
+
+### Step 8 — 테스트 + 검증
+
+```bash
+sqlc generate
+mockery --name=TaskRepository --dir=internal/domain --output=mocks
+mockery --name=GitHubClient   --dir=internal/github --output=mocks
+mockery --name=CIFixUseCase   --dir=internal/usecase --output=mocks
+go build ./...
+go test -race -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out | tail -1   # ≥80%
+go tool cover -func=coverage.out | grep -E '(internal/ci|internal/usecase/ci_fix)' # ≥85%
+go vet ./...
+golangci-lint run ./...
+swag init -g cmd/scheduled-dev-agent/main.go -o docs
+```
+
+**수락 기준 (전체)**
+- 전체 명령 0 exit
+- `.claude/hooks/pre-push.sh` 통과
+- swagger 에 `GET/PATCH /modes/ci-fix`, `TaskResponse` 의 신규 필드 노출
+- 회귀: 기존 `Worker.markDone` 단위 테스트 통과 (워크트리 cleanup 분기 변경 검증)
+
+**Sub-agent**: `go-tester`
+
+---
+
+## 2. PRD 수락 기준 매핑
+
+| PRD Goal | 검증 방법 |
+|----------|-----------|
+| G1. 실패 → enqueue 2분 이내 | poll_interval=60s 기본, watcher tick 단위 테스트 (mock clock) |
+| G2. max 2회 후 escalate | usecase test 의 `IsExhausted` 분기, exhausted 시 Slack 호출 mock |
+| G3. 동일 (parent, sha) 0/1 INSERT | repository 통합 테스트 (UNIQUE INDEX) + usecase test (FindFixChild hit) |
+| G4. window/budget/rate gate enforced | scheduler 통합 테스트 — fix task 도 dispatch 시 gate 통과 |
+| G5. 프롬프트에 step + log tail 포함 | prompt_builder 단위 테스트 (template 출력 검증) |
+| G6. worker pipeline 변경 최소화 | markDone hook 회귀 테스트 (기존 happy path 변경 0건) |
+
+| PRD User Story | 검증 |
+|----------------|------|
+| US-1 (자동 fix 커밋) | watcher e2e + usecase + repository |
+| US-2 (max attempts) | usecase IsExhausted 분기 |
+| US-3 (FailedStep + LogTail) | log_extractor + prompt_builder + secret_mask 테스트 |
+| US-4 (게이트 enforced) | scheduler test (window 밖 fix task = queued 상태 유지) |
+| US-5 (중복 방지) | UNIQUE INDEX + usecase mock test |
+| US-6 (조회 API) | mode/ci-fix + task list `ci_status=` 필터 httptest |
+| US-7 (글로벌 토글) | `PATCH /modes/ci-fix` httptest + watcher tick 스킵 검증 |
+
+---
+
+## 3. CLAUDE.md NEVER 체크리스트
+
+- [ ] `domain/` 외부 패키지 import 금지 — `Task` struct 에 time.Time / string / int 만, gh-go SDK import 없음
+- [ ] raw SQL 금지 — `db/query/task_ci.sql` + `sqlc generate` 만, GORM raw `db.Exec` 금지
+- [ ] 전역 var db 금지 — `cmd/main.go` 에서 모든 의존성 주입
+- [ ] `context.Background()` 핸들러 직접 사용 금지 — `c.Request.Context()`. watcher tick 은 scheduler 가 전달한 ctx 사용
+- [ ] swag 주석 없는 endpoint 추가 금지 — `/modes/ci-fix` GET/PATCH 둘 다 godoc
+- [ ] 기존 migration 파일 수정 금지 — 000004 / (필요 시 000005) 신규만
+- [ ] 테스트 없이 UseCase 메서드 추가 금지 — `EnqueueFixTask`, `MarkCIStatus`, `IsExhausted`, `ListWatching` 모두 단위 테스트 동시 추가
+- [ ] secret 로그 노출 금지 — log_extractor 출력은 secret_mask 거친 후에만 prompt 에 삽입, slog 출력에도 raw log 직접 미노출
+- [ ] `panic()` 금지 — gh CLI 실패는 retry 후 degrade
+
+---
+
+## 4. OI / 후속 결정 필요 (PRD §12 와 동기화)
+
+- OI-1 secret 마스킹 패턴 보강은 실측 fixture 누적 후 `internal/ci/secret_mask.go` 에 추가 (테스트 케이스 형태로 누적)
+- OI-2 human push 감지 룰은 `internal/ci/watcher.go` 의 `isHumanPush()` 헬퍼로 격리 — bot 화이트리스트 (`github-actions[bot]`, `dependabot[bot]`, 운영자 PAT user) config 노출 검토
+- OI-3 `comment_on_exhaustion` 토글은 config 에 이미 반영. usecase 의 exhausted 분기에서 토글 체크
+- OI-4 inline polling 으로 v1 구현. watching 누적 cap (예: 50) 초과 시 `slog.Warn` 후 가장 오래된 것부터 `closed` 강제 — v1.1 검토
+- OI-5 `prompts/ci-fix.tmpl` 텍스트는 모 PRD §12 OI-7 prompt 정책과 일관되게 작성, 별도 리뷰 필요
+
+---
+
+## 5. 후속 수동 작업
+
+```bash
+# 첫 실행 전
+sqlc generate
+mockery --all --dir=internal/domain --output=mocks
+swag init -g cmd/scheduled-dev-agent/main.go -o docs
+
+# config.example.yaml 에 ci_fix 블록 추가 + README "CI Fix Loop" 섹션 보강
+```

--- a/docs/specs/github-webhook.md
+++ b/docs/specs/github-webhook.md
@@ -87,6 +87,7 @@
 
 - **서명 헤더 누락 / 검증 실패**: 401 + slog Warn (`signature_verification_failed`). body 무시.
 - **timestamp replay (5분 초과)**: GitHub webhook 은 timestamp 헤더가 없으므로 **delivery_id 캐시** 가 replay 방지 책임. 동일 delivery 5분 이내 재수신 시 200 + ignore.
+  > **OI 결정 (2026-04-27)**: Slack 의 `X-Slack-Request-Timestamp` 와 달리 GitHub 는 공식 timestamp 헤더를 제공하지 않는다. 따라서 "5분 replay window" 는 `webhook_dedup` 의 delivery-ID TTL(기본 5분)로 구현된다. `webhook_verifier.go` 상단 주석에도 동일 내용 기록됨. <!-- OI-resolved: replay window via dedup TTL -->
 - **allowlist 바깥 레포**: 200 + `ignored: not_in_allowlist` 로그. 401 이 아닌 200 으로 응답해야 GitHub 가 재시도하지 않음.
 - **PR 이벤트** (`issue.pull_request != nil`): 200 + ignore.
 - **라벨 미매치** (`labeled` 이벤트지만 필터 라벨이 빠진 경우): 200 + ignore.
@@ -193,6 +194,14 @@ hmac.Equal(expected, request.Header["X-Hub-Signature-256"])
 - **R3 (Med)**: dedup 캐시 누락 (재시작 직후 5분 grace period 끝나기 전 재시작 반복) → 동일 이슈 race. 완화: `ExistsByRepoAndIssue` 가 2차 방어선. v1.1 에서 DB UNIQUE 제약 추가 검토
 - **R4 (Low)**: 서명 검증에서 raw body 가 아닌 파싱된 body 를 검증해 mismatch → Gin 의 `c.Request.Body` 를 `io.ReadAll` 한 후 검증해야 함. 기존 Slack handler 와 동일 패턴
 - **R5 (Low)**: GitHub 이 webhook 을 SHA-1 (`X-Hub-Signature`) 으로도 보낼 수 있음 → v1 은 SHA-256 만 지원, SHA-1 은 무시 (GitHub 가 둘 다 보내므로 안전)
+
+## 11. 설계 결정 기록 (Design Decisions)
+
+| 결정 | 내용 | 일자 |
+|------|------|------|
+| Replay window 구현 방식 | GitHub 공식 timestamp 헤더 부재로 5분 replay window 는 `webhook_dedup` delivery-ID TTL 로 대체. `webhook_verifier.go` 주석 + §6.2 에 명시. | 2026-04-27 |
+| Secret 미설정 시 라우트 미등록 | `GITHUB_WEBHOOK_SECRET` 미설정 시 `/github/webhook` 라우트 자체를 등록하지 않아 엔드포인트 존재 노출 방지 (503 → 404). `api.NewRouter` + `cmd/main.go` 에 반영. | 2026-04-27 |
+| dedup TOCTOU race 제거 | `sync.Map LoadOrStore → TTL check → Store` 패턴을 `sync.Mutex + map[string]time.Time` 으로 교체. `CheckAndAdd` + `evictExpired` 전체를 단일 lock 내에서 수행. | 2026-04-27 |
 
 ## 11. 범위 외 (Out of Scope)
 

--- a/docs/specs/github-webhook.md
+++ b/docs/specs/github-webhook.md
@@ -1,0 +1,229 @@
+# PRD — github-webhook
+
+| 항목 | 값 |
+|------|-----|
+| 작성일 | 2026-04-27 |
+| 상태 | draft |
+| 스택 범위 | Go (단일 바이너리 — `scheduled-dev-agent` 에 추가) |
+| 우선순위 | P1 |
+| 작성자 | gs97ahn@gmail.com |
+| 상위 PRD | [`./scheduled-dev-agent.md`](./scheduled-dev-agent.md) §8 OI-5 해소 |
+
+---
+
+## 1. 배경 (Background)
+
+현재 `internal/github/poller.go` 는 `runtime.tick_interval` (기본 30s) 주기로 GitHub `Issues.ListByRepo` 를 호출해 새 이슈를 enqueue 한다. 이 방식은 **활성 시간대 이내에서도 이슈가 올라온 직후 최대 30초 + GitHub eventual consistency 지연** 이 task 시작까지 누적된다는 문제가 있다. 운영자가 라벨을 붙였는데도 즉각 반응하지 않는 사용자 경험은 "예약 자동화" 라기보다 "지연 자동화" 로 보인다.
+
+이 기능은 **GitHub webhook 엔드포인트 (`POST /github/webhook`)** 를 노출해 이슈 이벤트를 즉시 수신·enqueue 하여 polling latency 를 30s → **< 2s (p95)** 로 단축한다. polling 은 **fallback 으로 그대로 유지** 한다 — 네트워크 단절·webhook delivery 실패·서비스 재시작 시 누락된 이벤트를 다음 tick 에서 회수하기 위함.
+
+핵심 제약:
+- **인증**: GitHub webhook secret 으로 HMAC-SHA256 서명 검증 (이미 `internal/slack/verify.go` 에 동일 패턴 존재 — 차용)
+- **idempotency**: `X-GitHub-Delivery` UUID 를 키로 중복 처리 방지 (재전송·polling 과의 race)
+- **활성 시간대 게이트**: webhook 으로 enqueue 되더라도 dispatch 는 기존 scheduler 의 active window + budget gate 를 그대로 통과해야 한다
+- **레포 allowlist · 라벨 필터**: polling 과 동일 규칙 적용
+
+## 2. 목표 (Goals)
+
+- G1. 이슈에 `claude-ops` (config 의 `repo.labels` AND 매치) 라벨이 추가되면 **p95 < 2s 이내** task 가 `queued` 상태로 INSERT 됨
+- G2. 동일 delivery (재전송) 또는 polling 과 webhook 이 같은 이슈를 동시에 발견해도 **Task row 는 정확히 1개만** 생성됨 (dedup)
+- G3. webhook secret 검증 실패 / replay window (5분) 초과 / allowlist 바깥 레포 이벤트는 **401 또는 무시** 되며 task INSERT 0건
+- G4. polling 은 그대로 동작 — webhook 이 죽거나 network 가 단절된 동안 누락된 이슈는 다음 polling tick 이 회수
+- G5. webhook 처리 자체는 **active window 와 무관** 하게 즉시 enqueue (status=queued). 실제 dispatch 는 기존 scheduler 게이트가 결정
+
+## 3. 비목표 (Non-goals)
+
+- v1 은 **`issues` 이벤트만** 처리 (action: `opened`, `labeled`). `pull_request`, `push`, `issue_comment` 는 후순위
+- GitHub App 방식 (JWT, installation token) — v1 은 **레포 webhook + shared secret** 만
+- Webhook delivery 누락 자동 재요청 (GitHub Redelivery API) — polling 으로 자연 회수
+- 외부 노출용 reverse proxy 설정 자동화 (운영자가 직접 nginx/Caddy/cloudflared 등으로 구성)
+- 이벤트별 metric/대시보드 (slog 로그만)
+- webhook URL 자체의 회전·교체 자동화
+
+## 4. 대상 사용자 (Users)
+
+| 페르소나 | 역할 | 목표 |
+|----------|------|------|
+| Solo developer | 홈서버에 서비스 운영, GitHub repo 관리자 | 라벨 단 이슈가 즉시 PR 까지 진행되길 원함 |
+| Small team lead | 1~3 인 팀 테크 리드 | webhook 누락 대비 polling fallback 신뢰성 확인 |
+
+상위 PRD 와 동일하게 **운영자 = GitHub repo 관리자 = Slack 채널 운영자** 단일 페르소나.
+
+## 5. 유저 스토리 (User Stories)
+
+| # | 스토리 | 수락 기준 |
+|---|--------|-----------|
+| US-1 | 운영자로서 이슈에 `claude-ops` 라벨을 추가하면 **즉시** task 가 큐잉되길 원한다 | 1) GitHub `issues` 이벤트 (action: `labeled`) 수신 → 라벨 추가 시점 → Task INSERT 까지 p95 < 2s <br> 2) 라벨 매치는 polling 과 동일 (config 의 `repo.labels` AND 조건) <br> 3) Task `task_type` 은 polling 과 동일한 `detectTaskType` 로직 적용 |
+| US-2 | 운영자로서 새 이슈 (action: `opened`) 가 라벨과 함께 올라오면 즉시 큐잉되길 원한다 | 1) `issue.labels[]` 가 라벨 필터를 만족하면 INSERT <br> 2) 라벨 미매치면 무시 (응답 200 + 로그) <br> 3) `issue.pull_request != nil` 이면 무시 (PR 이벤트는 v1 범위 외) |
+| US-3 | 운영자로서 webhook 가짜 호출로 task 가 생성되지 않길 원한다 | 1) `X-Hub-Signature-256` 헤더 누락 → 401 <br> 2) HMAC-SHA256 검증 실패 → 401 <br> 3) `X-GitHub-Delivery` 헤더 누락 → 400 <br> 4) GitHub 의 ping 이벤트 (`X-GitHub-Event: ping`) → 200 + 무시 |
+| US-4 | 운영자로서 동일 이벤트 재전송 / polling 중복으로 task 가 두 번 생기지 않길 원한다 | 1) 동일 `X-GitHub-Delivery` UUID 가 5분 이내 재수신되면 무시 (응답 200) <br> 2) polling 과 webhook 이 같은 (repo, issue_number) 를 동시에 봐도 `tasks` row 는 1개 (`ExistsByRepoAndIssue` 재확인 + UNIQUE 제약) <br> 3) dedup 캐시는 in-memory + AppState 영속 (재시작 시에도 1시간 보존) |
+| US-5 | 운영자로서 webhook 이 잠시 끊겨도 polling 으로 누락 이슈를 회수하길 원한다 | 1) webhook 503/network 단절 시 GitHub 가 재전송하지 못해도 다음 polling tick (≤ poll_interval) 이 동일 이슈를 발견해 INSERT <br> 2) polling 과 webhook 둘 다 INSERT 시도해도 US-4 의 dedup 으로 1개만 생성 <br> 3) 운영자가 webhook 비활성화하고 polling 만으로 운영 가능 (config 토글) |
+| US-6 | 운영자로서 webhook 수신 로그를 사후에 확인하고 싶다 | 1) 모든 수신 webhook 은 slog JSON 로그로 기록: `{event, action, delivery_id, repo, issue, accepted/ignored, latency_ms}` <br> 2) PII (issue body) 는 로그에 남기지 않음 (title, number 만) <br> 3) `TaskEvent` 의 `kind=started` payload 에 `source: "webhook"` 또는 `"polling"` 추가하여 사후 추적 |
+| US-7 | 운영자로서 webhook 자체에 의해 active window 가 무시되지 않길 원한다 | 1) webhook 으로 enqueue 된 task 도 scheduler 의 window gate 를 통과해야 dispatch 됨 (window 밖이면 status=queued 인 채로 대기) <br> 2) full mode 토글·budget gate 도 그대로 enforced <br> 3) e2e 테스트: window 밖 webhook 수신 → INSERT 됨 → claude exec 호출 0회 검증 |
+
+## 6. 핵심 플로우 (Key Flows)
+
+### 6.1 행복 경로 — webhook 즉시 수신
+
+```
+1. GitHub 이슈에 'claude-ops' 라벨 추가
+2. GitHub → POST /github/webhook
+   헤더: X-Hub-Signature-256, X-GitHub-Delivery, X-GitHub-Event: issues
+   바디: { action: "labeled", issue: {...}, repository: {...}, label: {...} }
+3. 핸들러: raw body 읽기 → HMAC-SHA256 검증
+4. event=ping → 200 즉시 반환
+5. event=issues, action ∈ {opened, labeled}: 처리
+   - allowlist 체크: repository.full_name 이 config.github.repos[].name 에 있는지
+   - PR 이벤트 필터: issue.pull_request 가 있으면 무시
+   - 라벨 매치: hasAllLabels(issue, repo.labels)
+   - delivery_id dedup: cache.has(delivery_id) → 무시
+   - ExistsByRepoAndIssue → 이미 있으면 무시 (polling race)
+6. Task INSERT (status=queued, source=webhook 이벤트 payload 에 기록)
+7. 200 응답 (latency_ms 로그)
+8. 이후 scheduler tick → window/budget gate 통과 시 dispatch (기존 흐름)
+```
+
+### 6.2 예외 경로
+
+- **서명 헤더 누락 / 검증 실패**: 401 + slog Warn (`signature_verification_failed`). body 무시.
+- **timestamp replay (5분 초과)**: GitHub webhook 은 timestamp 헤더가 없으므로 **delivery_id 캐시** 가 replay 방지 책임. 동일 delivery 5분 이내 재수신 시 200 + ignore.
+- **allowlist 바깥 레포**: 200 + `ignored: not_in_allowlist` 로그. 401 이 아닌 200 으로 응답해야 GitHub 가 재시도하지 않음.
+- **PR 이벤트** (`issue.pull_request != nil`): 200 + ignore.
+- **라벨 미매치** (`labeled` 이벤트지만 필터 라벨이 빠진 경우): 200 + ignore.
+- **JSON 파싱 실패**: 400 + slog Error.
+- **DB INSERT 실패** (`ExistsByRepoAndIssue` 또는 `Create`): 500 — GitHub 가 재시도 → 다음 시도에서 dedup 으로 자연 해소.
+- **action 이 `unlabeled`/`closed`/`assigned` 등 v1 외**: 200 + ignore.
+- **content-type 불일치** (`application/json` 외): 400.
+
+### 6.3 polling fallback 플로우 (변경 없음)
+
+기존 `internal/github/poller.go` 는 그대로 동작. webhook 활성 여부와 무관하게 `runtime.tick_interval` 마다 호출. webhook 으로 이미 INSERT 된 이슈는 `ExistsByRepoAndIssue == true` 로 자연 스킵.
+
+운영자가 webhook 만 사용하고 싶다면 config 의 `github.poll_interval` 을 길게 (예: 10m) 설정하여 fallback 빈도만 낮춤. 단, 완전 비활성화는 권장하지 않음 (R2 참조).
+
+## 7. 데이터 모델 (요약)
+
+신규 테이블 없음. 기존 `Task`, `TaskEvent`, `AppState` 재사용.
+
+```
+Task (변경 없음)
+TaskEvent.payload_json: { source: "webhook"|"polling", delivery_id?: "uuid" }   # ADDED: 사후 추적용
+AppState
+    key="webhook_dedup"   value={ deliveries: { "uuid": expires_at_unix, ... } }   # NEW
+        — 메모리 캐시 + 1시간 단위 flush. 재시작 직후 5분 grace period 동안만 영속본 사용
+```
+
+dedup 캐시 구현:
+- in-memory: `sync.Map[deliveryID]expiresAt` — 5분 TTL
+- AppState 영속: 1분 단위 flush 로 재시작 후에도 5분 grace period 보장 (write 비용 < dedup 정확성)
+- v1 은 단일 머신·단일 프로세스 전제이므로 분산 dedup 불필요
+
+`tasks` 테이블에는 **UNIQUE INDEX (repo_full_name, issue_number) WHERE status IN ('queued', 'running')** 제약을 추가 검토 — 이미 `ExistsByRepoAndIssue` 가 있으므로 v1 은 우선 application-layer dedup 만, race 발생 시 v1.1 에서 DB 제약 추가.
+
+## 8. API 계약 (요약)
+
+상위 PRD §8 의 placeholder (`POST /github/webhook`) 를 실제로 구현.
+
+```
+POST /github/webhook
+  Headers:
+    Content-Type:        application/json
+    X-Hub-Signature-256: sha256=<hex>      # GitHub HMAC-SHA256 서명 (필수)
+    X-GitHub-Delivery:   <uuid>            # delivery 식별자 (필수, dedup 키)
+    X-GitHub-Event:      issues|ping|...   # 이벤트 종류 (필수)
+  Body:                  GitHub IssueEvent payload (https://docs.github.com/webhooks/webhook-events-and-payloads#issues)
+
+  Responses:
+    200 OK              { accepted: bool, reason?: "queued"|"ignored:..."|"duplicate" }
+    400 Bad Request     ErrorResponse — 헤더 누락 또는 JSON 파싱 실패
+    401 Unauthorized    ErrorResponse — 서명 검증 실패
+    500 Internal Error  ErrorResponse — DB 오류 (GitHub 가 재시도)
+```
+
+응답 DTO (swag godoc 필수):
+
+```go
+// WebhookResponse is the response for POST /github/webhook.
+type WebhookResponse struct {
+    Accepted bool   `json:"accepted" example:"true"`
+    Reason   string `json:"reason,omitempty" example:"queued"`
+    TaskID   string `json:"task_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
+}
+```
+
+서명 검증 알고리즘 (GitHub 공식):
+
+```
+expected = "sha256=" + hex(HMAC_SHA256(secret, raw_body))
+hmac.Equal(expected, request.Header["X-Hub-Signature-256"])
+```
+
+**기존 `internal/slack/verify.go` 와의 차이점**:
+- Slack 은 `v0=<hex>` + timestamp 별도 헤더, GitHub 는 `sha256=<hex>` 단일 헤더
+- timestamp replay 방어가 GitHub 헤더에 없음 → **delivery_id 캐시** 로 대체
+- HMAC 알고리즘은 동일 (`crypto/hmac` + `crypto/sha256`)
+
+## 9. 비기능 요구사항 (Non-functional)
+
+| 항목 | 요구 |
+|------|------|
+| 성능 | webhook → Task INSERT p95 < 2s (network 지연 제외 < 200ms 처리) |
+| 보안 | secret 은 환경변수 (`GITHUB_WEBHOOK_SECRET`), config.yaml 금지. 검증 실패는 모두 401 |
+| 보안 | constant-time 비교 (`hmac.Equal`) — timing attack 방지 |
+| Idempotency | 동일 delivery_id 재수신 → no-op + 200. 메모리 + AppState dual layer |
+| 관측성 | slog JSON: `{event, action, delivery_id, repo, issue, accepted, reason, latency_ms}` |
+| 신뢰성 | webhook 다운 / 검증 실패 시에도 polling 이 fallback. e2e 테스트로 검증 |
+| 활성 시간 게이트 | webhook 은 enqueue 만, dispatch 는 기존 window/budget gate 통과 필수 |
+| 테스트 커버리지 | 80% 이상 (Go CLAUDE.md 게이트) — webhook handler · 검증·dedup 은 **85% 이상** |
+| lint | `golangci-lint run ./...` 통과 필수 |
+| 문서 | swag godoc 필수 — `/swagger/index.html` 에 `POST /github/webhook` 노출 |
+
+## 10. 의존성 / 리스크
+
+**의존성**
+- 기존 `internal/slack/verify.go` 의 HMAC 패턴 (참고용 — 코드 재사용보다는 패턴 차용)
+- 기존 `internal/github/poller.go` 의 `hasAllLabels` / `detectTaskType` 함수 — webhook handler 도 같은 함수 호출하도록 export 또는 분리 필요
+- 외부 노출 — 운영자가 reverse proxy (nginx, Caddy, cloudflared tunnel 등) 로 `/github/webhook` 만 공개. v1 은 문서화만, 자동 구성 안 함
+- GitHub webhook 등록 — 운영자가 GitHub repo Settings → Webhooks 에서 수동 등록 (Payload URL, Secret, Events: Issues)
+
+**리스크**
+
+- **R1 (High)**: 외부 공개 webhook 엔드포인트 → DDoS / 봇 스캔. 완화: rate limit middleware (IP 별 60req/min), 검증 실패 시 빠른 401, body 크기 제한 (1MB)
+- **R2 (Med)**: webhook 만 신뢰하고 polling 비활성화 → GitHub delivery 누락 시 영구 미처리. 완화: README 와 config.example.yaml 에 "polling 은 항상 활성화 권장" 명시. v1 은 polling 비활성화 토글을 의도적으로 제공하지 않음 (poll_interval 만 조절 가능)
+- **R3 (Med)**: dedup 캐시 누락 (재시작 직후 5분 grace period 끝나기 전 재시작 반복) → 동일 이슈 race. 완화: `ExistsByRepoAndIssue` 가 2차 방어선. v1.1 에서 DB UNIQUE 제약 추가 검토
+- **R4 (Low)**: 서명 검증에서 raw body 가 아닌 파싱된 body 를 검증해 mismatch → Gin 의 `c.Request.Body` 를 `io.ReadAll` 한 후 검증해야 함. 기존 Slack handler 와 동일 패턴
+- **R5 (Low)**: GitHub 이 webhook 을 SHA-1 (`X-Hub-Signature`) 으로도 보낼 수 있음 → v1 은 SHA-256 만 지원, SHA-1 은 무시 (GitHub 가 둘 다 보내므로 안전)
+
+## 11. 범위 외 (Out of Scope)
+
+- `pull_request`, `push`, `issue_comment` 이벤트 (v2)
+- GitHub App 인증 (v2)
+- Redelivery API 자동 호출 (polling 으로 충분)
+- 멀티 webhook (organization-level webhook) 지원 — v1 은 repo-level 단일 secret
+- webhook 수신 메트릭 대시보드 (slog 로그만)
+- 이슈 closing/unlabeled 이벤트로 queued task 자동 cancel — v1 은 enqueue only
+
+## 12. 오픈 이슈 (Open Questions)
+
+- [ ] **OI-1**: 외부 노출 방식 권장 가이드 — Cloudflare Tunnel vs nginx + Let's Encrypt vs ngrok. 홈서버 시나리오에서 어느 것을 README 기본 가이드로 채택할지. 보안 vs 설치 난이도 trade-off 결정 필요
+- [ ] **OI-2**: webhook secret 은 단일 secret 인가 multiple secret rotation 지원할 것인가. v1 은 단일이지만, GitHub Webhooks 는 multiple secret 을 지원하지 않으므로 사실상 결정됨 — rotation 은 운영자가 GitHub 측 secret + 환경변수 동시 교체 + 무중단 재시작 책임. README 에 명시할 것
+- [ ] **OI-3**: dedup 캐시의 in-memory + AppState dual layer 가 v1 에 과한가? 단일 머신·단일 프로세스이므로 in-memory 만으로 충분할 수도 있음. 재시작 직후 GitHub 재전송 빈도 측정 후 결정 — v1 초안은 in-memory 만, AppState 영속은 OI 로 보류
+- [ ] **OI-4**: webhook 수신 시 `TaskEvent` 에 `kind=webhook_received` 같은 신규 EventKind 를 추가할지, 기존 `started` 의 payload 만 확장할지. 후자가 단순하지만 사후 분석 시 별도 kind 가 더 직관적 — 결정 필요
+
+---
+
+## 참고 — 영향받는 기존 파일
+
+- `internal/api/server.go` — 새 라우트 등록
+- `internal/api/dto.go` — `WebhookResponse` 추가
+- `internal/api/errors.go` — 변경 없음 (신규 도메인 에러 없음)
+- `internal/config/config.go` — `Env.GitHubWebhookSecret` 필드 + `LoadEnv` 에 환경변수 매핑
+- `internal/config/validate.go` — `ValidateEnv` 에서 webhook secret 비어 있을 때 경고만 (필수 아님 — webhook 비활성화 모드 허용)
+- `internal/github/poller.go` — `hasAllLabels`, `detectTaskType` 을 패키지 외부에서도 호출 가능하도록 export (또는 webhook 코드를 같은 패키지에 두기)
+- `cmd/scheduled-dev-agent/main.go` — webhook handler DI 조립
+
+신규 파일은 `./github-webhook/go.md` 의 체크리스트 참조.
+
+---
+
+> 단일 스택 프로젝트이므로 역할별 분할 없이 **단일 구현 프롬프트** ([`./github-webhook/go.md`](./github-webhook/go.md)) 로 전달합니다.

--- a/docs/specs/github-webhook/go.md
+++ b/docs/specs/github-webhook/go.md
@@ -1,0 +1,236 @@
+# github-webhook — Go 구현 가이드
+
+상위 PRD: [`../github-webhook.md`](../github-webhook.md)
+
+> 이 문서는 PRD 의 내용을 반복하지 않습니다. 단계·수락 기준·체크리스트만 담습니다. 의사결정·근거는 PRD 본문을 참조하세요.
+
+---
+
+## 0. 사전 확인
+
+### CLAUDE.md 핵심 규칙 발췌
+- **DI**: 생성자 파라미터 주입만 — 전역 `var db *gorm.DB` 금지
+- **context**: 모든 레이어 `ctx context.Context` 첫 인자, 핸들러는 `c.Request.Context()` (주의: webhook handler 내부 `gin.Context` 가 raw body 를 한 번만 읽을 수 있다는 점)
+- **domain import 금지**: `internal/domain/` 은 GORM/gin/외부 패키지 import 금지
+- **sqlc**: 조건/페이징/조인은 sqlc — 단, 본 기능은 신규 쿼리 거의 없음 (in-memory dedup 우선)
+- **swag**: 모든 신규 핸들러에 `@Summary @Tags @Router @Success @Failure` godoc 필수
+- **Response DTO**: `example:"..."` json 태그 필수
+- **NEVER**: 시크릿 평문 로그, `panic()`, `domain/` 외부 import, swag 없는 endpoint, raw SQL 하드코딩
+- **커버리지 게이트**: ≥80% (`internal/api/webhook_*` · `internal/github/webhook` 패키지는 ≥85%)
+
+### 영향받는 기존 파일 (수정)
+- `cmd/scheduled-dev-agent/main.go` — DI 조립 (webhook handler / dedupCache / signature verifier 와이어업, env 전달)
+- `internal/api/server.go` — `POST /github/webhook` 라우트 등록 (Slack 라우트 옆)
+- `internal/api/dto.go` — `WebhookResponse` DTO 추가
+- `internal/api/errors.go` — 변경 없음 (signature/format 에러는 핸들러 내 status 직매핑)
+- `internal/config/config.go` — `Env.GitHubWebhookSecret` 필드 + `LoadEnv` 환경변수 매핑 (`GITHUB_WEBHOOK_SECRET`)
+- `internal/config/validate.go` — webhook secret 미설정 시 `slog.Warn("webhook disabled: GITHUB_WEBHOOK_SECRET not set")` (기능 비활성, 검증 통과)
+- `internal/github/poller.go` — `hasAllLabels`, `detectTaskType` 를 패키지 export 또는 webhook 코드를 같은 `internal/github` 패키지에 두기 (후자 권장 — DRY · 패키지 간 의존 최소)
+
+### 신규 생성 파일
+- `internal/github/webhook_verifier.go` — HMAC-SHA256 검증 (`internal/slack/verify.go` 패턴 차용, GitHub 헤더 형식)
+- `internal/github/webhook_dedup.go` — `sync.Map` 기반 in-memory dedup cache (5분 TTL, GC goroutine)
+- `internal/github/webhook_handler.go` — Gin 핸들러 (라우팅·검증·dedup·enqueue 오케스트레이션)
+- `internal/github/webhook_handler_test.go` — handler httptest 단위 테스트
+- `internal/github/webhook_verifier_test.go` — 시그니처 검증 단위 테스트 (table-driven)
+- `internal/github/webhook_dedup_test.go` — dedup TTL / 동시성 테스트
+
+> Migration 불필요. 신규 sqlc 쿼리 불필요 (기존 `ExistsByRepoAndIssue` · `Create` 재사용).
+
+---
+
+## 1. 단계별 작업
+
+### Step 1 — Migration
+**스킵.** in-memory dedup 만 사용 (PRD §7, OI-3 결정 — AppState 영속은 v1 보류).
+
+### Step 2 — Domain
+변경 없음. PRD §7 의 신규 컬럼 / 테이블 / EventKind 추가 모두 v1 보류.
+
+> 단, `TaskEvent.payload_json` 의 `kind=started` payload 에 `source: "webhook"|"polling"` 키를 추가하는 것은 payload 가 free-form JSON 이므로 도메인 변경 없음. enqueue 시 payload 에 키 하나 더 채우기만 하면 됨.
+
+### Step 3 — Repository
+변경 없음. 기존 `TaskRepository.ExistsByRepoAndIssue(ctx, repo, issue)` · `Create(ctx, task)` 사용.
+
+### Step 4 — UseCase
+**최소 변경.** 기존 `TaskUseCase.EnqueueFromIssue` (또는 polling 이 호출하는 동등 함수) 의 시그니처에 `source string` 인자를 1개 추가하여 webhook 과 polling 이 동일 경로로 enqueue 하도록 통일. payload 에 `source` 만 다르게 기록.
+
+**작업 내용**
+1. `internal/usecase/task_usecase.go` — `EnqueueFromIssue(ctx, issue, source)` 또는 매개변수 풍부화. `source` 는 enum 문자열 `"webhook"|"polling"`.
+2. polling 호출부 `internal/github/poller.go` 도 `source="polling"` 으로 동일 호출 경로 사용 (회귀 0건).
+
+**수락 기준**
+- polling 이 enqueue 한 task 의 TaskEvent (kind=started) payload 에 `"source":"polling"` 포함
+- webhook 이 enqueue 한 task 는 `"source":"webhout"` 포함 (오타 주의: `webhook`)
+- 두 경로가 같은 (repo, issue_number) 를 동시에 처리해도 `ExistsByRepoAndIssue` 가차이로 1건만 INSERT
+
+**Sub-agent**: `go-modifier`
+
+### Step 5 — Handler (verifier · dedup · gin handler)
+
+#### Step 5a. `internal/github/webhook_verifier.go`
+**작업 내용**
+- `type WebhookVerifier struct { secret []byte }`, `NewWebhookVerifier(secret string) *WebhookVerifier`
+- `Verify(rawBody []byte, signatureHeader string) error` — `sha256=<hex>` prefix 파싱 → `hmac.Equal` 비교
+- `secret` 비어 있으면 `ErrWebhookDisabled` 반환 (config 미설정 시 endpoint 자체 비활성)
+
+**수락 기준**
+- table-driven 테스트: `valid` / `prefix mismatch` / `hex decode error` / `wrong secret` / `missing header` 5케이스 모두 expected error 일치
+- `hmac.Equal` 사용 (timing attack 방지) — golangci-lint `gosec` 통과
+- 테스트 커버리지 ≥ 95%
+
+**Sub-agent**: `go-generator`
+
+#### Step 5b. `internal/github/webhook_dedup.go`
+**작업 내용**
+- `type DedupCache interface { CheckAndAdd(deliveryID string) bool /* true=accepted, false=duplicate */ }`
+- 구현: `sync.Map[string]time.Time`, TTL 5분
+- 백그라운드 GC goroutine (`time.Ticker(60s)` 마다 만료 항목 제거) — `Stop()` 메서드로 중지 가능
+- 주입: `cmd/main.go` 가 `NewMemDedupCache(ctx, ttl)` 로 생성 후 `ctx.Done()` 시 자동 종료
+
+**수락 기준**
+- 동일 `deliveryID` 재호출 시 false 반환
+- 5분 + 1초 후 동일 ID 재호출 시 true 반환 (TTL 동작 확인 — `clock` 인터페이스 주입으로 테스트 결정성 확보)
+- 동시성 테스트: 1000 goroutine × 같은 ID → 정확히 1개만 true (race detector `-race` 통과)
+- 커버리지 ≥ 90%
+
+**Sub-agent**: `go-generator`
+
+#### Step 5c. `internal/github/webhook_handler.go`
+**작업 내용 — 처리 순서 (PRD §6.1 와 1:1)**
+1. `ctx := c.Request.Context()`
+2. `body, err := io.ReadAll(c.Request.Body)` — body 1MB cap (`http.MaxBytesReader`)
+3. `event := c.GetHeader("X-GitHub-Event")` — 누락 시 400
+4. `delivery := c.GetHeader("X-GitHub-Delivery")` — 누락 시 400
+5. `sig := c.GetHeader("X-Hub-Signature-256")` — 누락 시 401
+6. `verifier.Verify(body, sig)` 실패 시 401 (slog.Warn 만, body 미로깅)
+7. `event == "ping"` → 200 `{accepted:true, reason:"ping"}` 즉시 반환
+8. `event != "issues"` → 200 `{accepted:false, reason:"ignored:event_not_supported"}` 반환
+9. `dedupCache.CheckAndAdd(delivery)` false 면 200 `{accepted:false, reason:"duplicate"}`
+10. JSON unmarshal `IssueEvent` (action, issue, repository, label) — 실패 시 400
+11. `event.Issue.PullRequest != nil` → 200 `{accepted:false, reason:"ignored:pr_event"}`
+12. action ∉ `{"opened", "labeled"}` → 200 `{accepted:false, reason:"ignored:action"}`
+13. allowlist 체크: `repository.full_name ∈ config.GitHub.Repos[].Name` — 미매치 시 200 `{accepted:false, reason:"ignored:not_in_allowlist"}`
+14. 라벨 매치: `hasAllLabels(issue.Labels, repoCfg.Labels)` — false 시 200 `{accepted:false, reason:"ignored:label_mismatch"}`
+15. `taskRepo.ExistsByRepoAndIssue(ctx, repo, issueNumber)` true 면 200 `{accepted:false, reason:"duplicate"}`
+16. `taskUC.EnqueueFromIssue(ctx, issue, "webhook")` 호출
+17. INSERT 실패 시 500 (GitHub 가 재시도 → dedup 으로 자연 해소)
+18. 200 `{accepted:true, reason:"queued", task_id:<uuid>}` + `slog.Info("webhook accepted", event, action, delivery, repo, issue, latency_ms)`
+
+**swag godoc**
+```go
+// HandleWebhook ingests GitHub issue webhooks.
+//
+// @Summary  Receive GitHub webhook
+// @Tags     github
+// @Accept   json
+// @Param    X-Hub-Signature-256 header string true "HMAC-SHA256 signature"
+// @Param    X-GitHub-Delivery   header string true "Delivery UUID"
+// @Param    X-GitHub-Event      header string true "Event type (issues, ping)"
+// @Success  200 {object} api.WebhookResponse
+// @Failure  400 {object} api.ErrorResponse
+// @Failure  401 {object} api.ErrorResponse
+// @Failure  500 {object} api.ErrorResponse
+// @Router   /github/webhook [post]
+```
+
+**수락 기준 (httptest 단위)**
+- 모든 PRD §6.2 예외 경로 케이스에 대해 status code · response body 일치하는 table-driven 테스트
+- 검증 실패 / dedup hit / allowlist 외 케이스에서 `taskUC.EnqueueFromIssue` 호출 0회 (mockery 검증)
+- happy path 에서 `EnqueueFromIssue` 정확히 1회 호출, payload `source="webhook"`
+- e2e 풍 테스트: window 밖에서 webhook 수신 → enqueue 됨 → claude exec 호출 0회 (scheduler mock — US-7)
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 6 — DI 조립 (`cmd/scheduled-dev-agent/main.go`)
+**작업 내용**
+1. `cfg.Env.GitHubWebhookSecret` 로드 → `verifier := github.NewWebhookVerifier(secret)`. 비어 있으면 verifier `nil` (handler 내 nil 가드 → 503 또는 라우트 미등록)
+2. `dedup := github.NewMemDedupCache(rootCtx, 5*time.Minute)`
+3. `webhookHandler := github.NewWebhookHandler(verifier, dedup, taskUC, taskRepo, &cfg.GitHub, slog)`
+4. `server.go` 의 `RegisterRoutes` 에 `r.POST("/github/webhook", webhookHandler.Handle)` 추가
+5. body size limit middleware: `r.POST("/github/webhook", maxBytesMiddleware(1<<20), webhookHandler.Handle)` (1MB)
+
+**수락 기준**
+- `go build ./...` 통과
+- `go test ./cmd/...` 통과
+- secret 미설정 부팅 → `slog.Warn("github webhook disabled")` 1회, polling 은 정상 동작
+
+**Sub-agent**: `go-modifier`
+
+### Step 7 — 테스트
+- **handler**: `webhook_handler_test.go` — httptest + mockery (`TaskUseCase`, `TaskRepository`)
+- **verifier**: `webhook_verifier_test.go` — table-driven, GitHub 공식 예제 시그니처 fixture 1개 포함
+- **dedup**: `webhook_dedup_test.go` — `clock` 주입, `-race` 동시성 테스트
+- **e2e (선택)**: `internal/api/server_test.go` 에 `POST /github/webhook` 라우트 등록 검증 (404 아님)
+
+**커버리지 게이트**
+```bash
+go test -race -coverprofile=coverage.out ./internal/github/...
+go tool cover -func=coverage.out | grep -E '(webhook|verifier|dedup)' # ≥85%
+```
+
+**Sub-agent**: `go-tester`
+
+### Step 8 — 검증
+```bash
+go build ./...
+go test -race ./...
+go vet ./...
+golangci-lint run ./...
+swag init -g cmd/scheduled-dev-agent/main.go -o docs   # /swagger 에 POST /github/webhook 노출 확인
+```
+
+`mockery --name=TaskUseCase --dir=internal/usecase --output=mocks` (시그니처 변경 시).
+
+**수락 기준 (전체 종료 게이트)**
+- 모든 명령 0 exit
+- `/swagger/index.html` 에서 `POST /github/webhook` 보임
+- `.claude/hooks/pre-push.sh` 통과 (커버리지 ≥80%)
+
+---
+
+## 2. PRD 수락 기준 매핑
+
+| PRD Goal | 검증 방법 |
+|----------|-----------|
+| G1. 라벨 → INSERT p95 < 2s | handler 단위 테스트 latency < 200ms (network 제외) + 로컬 e2e 측정 |
+| G2. dedup (delivery + repo/issue) | webhook_dedup_test + handler test (`ExistsByRepoAndIssue=true` mock) |
+| G3. 401/무시 시 INSERT 0건 | handler test 의 모든 reject 케이스에서 `EnqueueFromIssue` mock 호출 횟수 0 검증 |
+| G4. polling fallback 유지 | 기존 poller_test 회귀 통과, source="polling" payload 검증 |
+| G5. window 무관 enqueue | scheduler mock + handler e2e — window 밖 입력 시 INSERT 1건 / dispatch 0건 |
+
+| PRD User Story | 검증 |
+|----------------|------|
+| US-1 (labeled) | handler test action="labeled" |
+| US-2 (opened + labels) | handler test action="opened" + labels 매치 |
+| US-3 (가짜 호출) | verifier test + handler 401/400 |
+| US-4 (재전송 dedup) | dedup test 5분 TTL |
+| US-5 (polling fallback) | poller 통합 회귀 |
+| US-6 (로그) | handler test 의 slog capture 검증 — body PII 미포함 |
+| US-7 (window 게이트) | scheduler mock e2e |
+
+---
+
+## 3. CLAUDE.md NEVER 체크리스트
+
+- [ ] `domain/` 패키지가 외부 패키지 (gin, gorm, github SDK) import 안 함 — 본 기능은 `internal/github/` 에 모두 두므로 자연 통과
+- [ ] raw SQL 하드코딩 없음 (sqlc 또는 기존 GORM 메서드만)
+- [ ] 전역 `var db` 없음, 모든 의존은 `cmd/main.go` 에서 생성자 주입
+- [ ] handler 안에서 `context.Background()` 직접 사용 금지 — `c.Request.Context()` 만
+- [ ] swag 주석 없는 endpoint 추가 금지 — `HandleWebhook` godoc 필수
+- [ ] 기존 migration 수정 금지 — 본 기능은 migration 없음
+- [ ] 테스트 없는 UseCase 메서드 추가 금지 — `EnqueueFromIssue(source)` 시그니처 변경 시 테스트 동시 갱신
+- [ ] webhook secret · raw body 를 로그에 남기지 않음 (slog Warn 도 secret 비포함)
+- [ ] `panic()` 금지 — 모든 에러는 status code 매핑
+
+---
+
+## 4. 후속 수동 작업
+
+운영자 가이드 (README 또는 docs 보강 — 본 PRD 범위 외이지만 인지 필요):
+1. GitHub repo Settings → Webhooks → Add webhook
+2. Payload URL: `https://<host>/github/webhook`, Content type: `application/json`
+3. Secret: `GITHUB_WEBHOOK_SECRET` 와 동일값
+4. Events: "Let me select" → Issues 만 체크
+5. reverse proxy (cloudflared / nginx / Caddy) 로 외부 노출 — OI-1 결정 후 가이드 업데이트

--- a/docs/specs/parallel-tasks.md
+++ b/docs/specs/parallel-tasks.md
@@ -1,0 +1,346 @@
+# PRD — parallel-tasks
+
+| 항목 | 값 |
+|------|-----|
+| 작성일 | 2026-04-27 |
+| 상태 | draft |
+| 스택 범위 | Go (단일 바이너리 — `scheduled-dev-agent` 의 scheduler/worker 확장) |
+| 우선순위 | P1 |
+| 작성자 | gs97ahn@gmail.com |
+| 상위 PRD | [`./scheduled-dev-agent.md`](./scheduled-dev-agent.md) §3 비목표 / §10 R3 / §12 OI-2 해소 |
+
+---
+
+## 1. 배경
+
+`scheduled-dev-agent` v1 은 §3 에서 "복수 Claude 세션 병렬 실행" 을 명시적으로 비목표로 두고, 세마포어 1개 (`scheduler.sem = make(chan struct{}, 1)`) 로 worker 를 직렬화해 동작한다. 이 제약은 ① Claude Code CLI 가 같은 머신·같은 로그인 세션 디렉토리(`~/.claude/`) 에 동시에 여러 프로세스가 쓸 때의 충돌 가능성, ② `git worktree` 가 같은 base branch 에서 동시 push 될 때의 충돌, ③ SQLite WAL 모드의 단일 writer 보장이라는 세 가지 위험 때문이었다.
+
+§12 OI-2 는 v1.1 에서 2~3 병렬을 검토하기로 보류된 항목이다. 현재 운영 데이터로는 직렬 1개 처리 시 일일 5건 cap 까지 도달하는 task 의 총 처리 시간이 단순 합계라, 활성 시간대 (예: 09:00–18:00, 9 시간) 안에 5건이 평균 task 길이 (~30분) × 5 = 2.5h 로 시간 자원이 남는다. 그러나 task 가 길어지거나 (CI fix loop 동반 시) cap 이 7~10 으로 올라가면 활성 시간대를 모두 소진하고도 대기열이 남는 시나리오가 임박했다.
+
+이 기능은 **동시 실행 슬롯을 1 → 2~3개로 확장** 하되, 위 세 가지 충돌 위험을 모두 게이트로 차단한다. 핵심 원칙은 "**병렬도는 config 로 점진적으로 올리고, 충돌 가능성이 0인 조합만 동시 dispatch**" 이다. 첫 release 는 `max_parallel_tasks=1` 기본값을 유지하여 v1 동작과 100% 동일하고, 운영자가 명시적으로 2 이상으로 올리는 시점부터만 병렬 코드 경로가 활성화된다 (feature-flag 방식).
+
+핵심 제약:
+- **Anthropic API key 금지** (상위 PRD 와 동일) — `claude` CLI 의 동시 실행 가능 여부는 **실측 spike 단계에서 검증**
+- **활성 시간 / budget gate / rate-limit block** 은 모든 병렬 슬롯에 동일하게 enforced
+- **같은 레포 동시 처리 금지** — v1.1 은 in-memory `sync.Map[repo]*sync.Mutex` 로 차단 (다른 레포끼리만 병렬)
+- **SQLite 단일 writer** — `sql.DB.SetMaxOpenConns(1)` 는 그대로 유지. dispatch 의 task pickup 은 row-level locking 패턴으로 race 방지
+- **Worker pool 패턴** — `errgroup.SetLimit(N)` 또는 N 워커 채널 패턴 (구현은 §6.4 참조)
+
+## 2. 목표 (Goals)
+
+- G1. `config.yaml` 의 `concurrency.max_parallel_tasks` (기본 `1`, 권장 최대 `3`) 로 동시 실행 슬롯 수를 선언적으로 조절. `0` 또는 `1` → v1 직렬 모드와 **바이트 동일** 동작
+- G2. 다른 레포의 task 는 동시에 dispatch 가능하되 **같은 레포의 task 는 항상 직렬**. 동일 (repo, issue) 에 대해 race 가 발생해도 Task INSERT/dispatch 는 정확히 1개
+- G3. 병렬 dispatch 시에도 active window / budget gate / rate-limit block 을 **각 슬롯마다 enforced** — 1개 슬롯이 budget 을 소진하면 다른 슬롯도 즉시 차단
+- G4. 한 task 의 실패 / 취소 / claude crash 가 다른 슬롯의 task 에 **영향 없음** (격리)
+- G5. **단계적 롤아웃** — `max_parallel_tasks=1` (v1.0 호환) → `2` (single-repo throughput 검증) → `3` (multi-repo cap) 로 운영자가 단계별 enable. 각 단계는 PRD §6.5 의 acceptance gate 를 통과해야 다음으로 이동
+- G6. v1 의 `Stop` API · Slack Stop button · graceful shutdown 모두 **모든 병렬 슬롯에 적용** — 한 슬롯의 SIGTERM 이 다른 슬롯에 영향 주지 않음
+
+## 3. 비목표 (Non-goals)
+
+- 분산 실행 (다중 머신·다중 프로세스 간 분산 락) — v1.1 도 **단일 머신·단일 프로세스** 전제
+- 같은 레포 내 동시 task 처리 (브랜치 충돌 회피 로직) — v2 후보, v1.1 은 single-flight per repo
+- 동시 슬롯 수 > 3 의 안정성 보증 — `max_parallel_tasks` 의 hard cap 은 코드에서 `3` 으로 막음 (운영자가 5, 10 등을 넣어도 3 으로 clamp + warn 로그)
+- task 우선순위 / 가중치 / 큐 재정렬 — FIFO 유지, 단 같은 레포 task 는 다른 레포 task 가 먼저 잡힐 수 있음 (head-of-line blocking 회피)
+- Claude CLI 의 `--session-id` 자동 격리 — v1.1 은 `~/.claude/` 동시 쓰기를 spike 결과 기반으로 결정 (필요 시 `HOME=$tmp/claude-N` 환경변수 격리 검토 — §10 R2)
+- 재시작 후 running task 자동 복구 — 상위 PRD §6.2 와 동일하게 orphan 표시만
+- 모니터링 대시보드 / metric 노출 — slog 로그 + 기존 `GET /tasks` 만
+
+## 4. 대상 사용자
+
+| 페르소나 | 역할 | 목표 |
+|----------|------|------|
+| Solo developer (P1) | 다중 레포 운영자 (예: 개인 프로젝트 3~5개) | 활성 시간대 안에 cap 까지 task 를 빨리 소진 |
+| Small team lead (P2) | 1~3인 팀, security/perf 자동화 늘리려는 운영자 | task throughput 을 하루 5건 → 10건 수준으로 확장 |
+
+권한 모델 변경 없음 — 단일 사용자, 단일 머신.
+
+## 5. 유저 스토리
+
+| # | 스토리 | 수락 기준 |
+|---|--------|----------|
+| US-1 | 운영자로서 **동시 실행 슬롯 수** 를 config 로 조절하고 싶다 | 1) `concurrency.max_parallel_tasks` (기본 `1`, 최소 `0`, 최대 `3`) 가 추가됨 <br> 2) `0` 또는 `1` → 기존 직렬 동작과 동일 (worker pool 코드 경로 자체가 비활성) <br> 3) `>3` 입력 시 `3` 으로 clamp + `slog.Warn("parallel: clamped to max=3")` <br> 4) config validate 에서 음수 / 비숫자 reject |
+| US-2 | 운영자로서 다른 레포의 task 가 **동시에** 진행되길 원한다 | 1) 다른 `repo_full_name` 을 가진 두 queued task 는 동시에 dispatch 됨 <br> 2) 동시 dispatch 의 시간차 < 200ms (scheduler tick 한 번 안에서) <br> 3) e2e 테스트: 두 개의 fake claude binary 가 stdout 을 동시에 흘리는 시점이 겹쳐야 통과 (`abs(start_a - start_b) < 200ms`) |
+| US-3 | 운영자로서 **같은 레포의 task** 가 동시에 돌지 않기를 원한다 | 1) 같은 `repo_full_name` 의 두 queued task 는 항상 직렬로 dispatch (한 쪽이 done/failed/cancelled 가 되어야 다른 쪽이 시작) <br> 2) repo-level mutex 는 in-memory `sync.Map[repo_full_name]*sync.Mutex` 로 구현 <br> 3) head-of-line 회피: 큐 첫 task 의 repo 가 lock 잡혀 있으면 **그 다음 task 부터 다른 repo 를 검색** (FIFO 가 아닌 "FIFO with skip-on-conflict") |
+| US-4 | 운영자로서 한 task 의 **실패가 다른 task 에 영향 없기를** 원한다 | 1) 한 슬롯의 worker goroutine 이 panic / crash 해도 scheduler 와 다른 슬롯은 계속 동작 (`recover()` + slog.Error) <br> 2) 한 슬롯의 `claude` 프로세스 SIGKILL 이 다른 슬롯의 pgid 에 영향 주지 않음 (각 task 별 독립 pgid 는 v1 에서도 이미 보장됨 — 검증만) <br> 3) e2e 테스트: 슬롯 A 가 fail 시점에 슬롯 B 는 정상 진행 검증 |
+| US-5 | 운영자로서 **모든 슬롯이 budget gate 를 enforce** 하는지 확신하고 싶다 | 1) daily/weekly cap 카운터 increment 는 **각 worker 가 spawn 직전에 atomic 하게** (BudgetEnforcer.CheckAndIncrement) — 병렬 구조에서도 race 없음 <br> 2) 두 슬롯이 동시에 cap 에 도달하면 둘 중 하나만 진행, 다른 하나는 cancel + Slack 통지 <br> 3) rate_limit_block 이 한 슬롯에서 발생하면 **다음 tick 부터 모든 슬롯이 차단** (AppState 단일 진실 공급원 그대로) |
+| US-6 | 운영자로서 **Stop API / Slack Stop 버튼** 으로 특정 task 만 중단시키고 싶다 | 1) `POST /tasks/{id}/stop` 은 해당 task 슬롯만 SIGTERM, 다른 슬롯에 영향 없음 <br> 2) Slack `stop_task` action 도 동일 — task_id 정확히 1개에만 적용 <br> 3) `cancelMap[task.ID]` 가 슬롯 수만큼 동시 보관됨 (sync.Map or sync.Mutex 보호) |
+| US-7 | 운영자로서 graceful shutdown 시 **모든 슬롯이 안전하게 종료** 되길 원한다 | 1) `Scheduler.Stop()` → 모든 슬롯의 ctx cancel → 각 worker 가 SIGTERM 후 30s 내 SIGKILL (v1 의 `claude.Canceller` 동작 그대로) <br> 2) 모든 슬롯의 worktree 는 `git worktree remove --force` 로 정리 <br> 3) `Scheduler.Stop()` 의 wg.Wait() 는 max(slot_drain_time) 만큼 기다림 (worker 별 timeout 30s + safety margin) |
+| US-8 | 운영자로서 단계적으로 병렬도를 올리고 싶다 (**spike → 2 → 3**) | 1) 첫 release 는 `max_parallel_tasks=1` 기본값으로 v1.0 와 동일 동작 검증 <br> 2) §6.5 의 spike 단계에서 fake claude 2개 동시 실행 충돌 여부 + `~/.claude/` 동시 쓰기 안전성을 e2e 측정 <br> 3) 통과 시 운영자가 `2` 로 올림 → 1주 운영 후 4가지 metric (성공률, claude crash 율, worktree 충돌, SQLite lock 에러) 모두 v1 대비 ±5% 안에 들어오면 `3` 으로 승격 <br> 4) §6.6 의 롤백 절차로 언제든지 `1` 로 즉시 복귀 가능 |
+
+## 6. 핵심 플로우
+
+### 6.1 행복 경로 — N 슬롯 동시 dispatch
+
+```
+1. scheduler tick (default 30s)
+2. active window + full mode 게이트 통과
+3. poller.Poll(ctx)  (free, 항상 실행)
+4. budget gate snapshot — 차단 사유 있으면 dispatch 전체 스킵
+5. for slot := 1..max_parallel_tasks:
+     5.1. worker pool 의 빈 슬롯 확인 (sem 채널 or errgroup limit)
+     5.2. queued task 1개 pick — repo lock 가능한 첫 task 우선
+          (taskRepo.PickNextDispatchable 호출, §7 참조)
+     5.3. 빈 슬롯 없으면 break
+     5.4. taskID 별 ctx + cancelFn 등록 (cancelMap)
+     5.5. go w.RunTask(taskCtx, task)
+6. 각 worker 는 v1 의 RunTask 파이프라인 그대로 실행
+   (provisionWorktree → renderPrompt → window double-gate → budget atomic check
+    → claude.Run → createPR → markDone)
+7. RunTask 끝나면 sem 슬롯 반납 + repo lock 해제 + cancelMap 제거
+```
+
+### 6.2 같은 레포 충돌 처리
+
+```
+큐 상태: [task-A(repo X), task-B(repo X), task-C(repo Y)]
+slots: 2
+
+tick 1:
+  - slot 1 픽업: task-A → repo X 락 획득 → dispatch
+  - slot 2 픽업 시도: 큐 다음 = task-B(repo X) → repo X 락 실패
+                       → 큐 next = task-C(repo Y) → repo Y 락 획득 → dispatch
+  - 결과: task-A + task-C 동시 진행, task-B 는 대기
+
+tick 2 (task-A 종료 후):
+  - slot 1 픽업: task-B(repo X) → repo X 락 획득 (A 가 해제) → dispatch
+```
+
+**구현 포인트**:
+- repo lock 은 in-memory `sync.Map[string]*sync.Mutex`. `TryLock()` 사용 (Go 1.18+).
+- 락 실패는 SQL 호출 없이 in-memory 결정 — tick latency 영향 없음.
+- 락은 `RunTask` 의 **시작~끝** 전 구간 보유. defer 로 해제.
+
+### 6.3 예외 경로
+
+- **한 슬롯 worker panic**: top-level `defer recover()` → slog.Error + Slack 통지 + task=failed. 다른 슬롯 영향 없음.
+- **claude CLI 동시 실행 시 세션 충돌 감지** (§10 R2 — spike 단계에서 측정): `~/.claude/sessions/` lock 파일 존재 시 `ErrSessionBusy` 반환. 임시 완화: 슬롯별 `HOME=$tmpdir/claude-{slot}` 환경변수 격리 검토. v1.1 의 첫 release 는 spike 결과에 따라 결정.
+- **두 슬롯이 동시에 같은 task 를 pick**: §7 의 atomic `UPDATE tasks SET status='running' WHERE id=? AND status='queued'` 패턴으로 정확히 1슬롯만 RowsAffected=1. 나머지는 다음 task 로 진행.
+- **budget gate 에서 한 슬롯이 cap 마지막 1슬롯을 가져감**: 다른 슬롯의 `CheckAndIncrement` 가 `BudgetReasonDailyCapReached` 반환 → cancel + Slack 통지.
+- **rate_limit_block 발생 (한 슬롯의 Claude CLI 가 wall hit)**: AppState `rate_limit_block` 영속 → 다른 슬롯의 worker 가 다음 spawn 직전 budget gate 에서 차단 → cancel.
+- **SQLite "database is locked" 에러**: `_busy_timeout=5000` (현재 설정) 으로 5s 까지 대기. 그래도 lock 되면 transient 에러로 분류 → 다음 tick 재시도. v1.1 에서 lock 발생률을 metric 으로 관찰.
+- **slot 수 변경 (config reload)**: v1.1 은 hot-reload 미지원 — config 변경은 재시작 필요. README 에 명시.
+- **graceful shutdown 중 새 dispatch**: `Stop()` 호출 후엔 `tick()` 이 즉시 return → 추가 dispatch 없음. 진행 중 task 만 drain.
+
+### 6.4 Worker pool 패턴 결정
+
+두 가지 후보:
+- **(A) `errgroup.WithContext` + `SetLimit(N)`**: Go 표준 ergonomic, 한 worker err 이 group 전체 cancel — v1.1 에는 부적합 (격리 요구 G4 위배).
+- **(B) N-buffered semaphore channel** + `sync.WaitGroup` (v1 의 `sem chan struct{}` 확장): 한 worker err 이 channel 통해 다른 worker 에 영향 없음. v1 의 `sem = make(chan struct{}, 1)` 을 `make(chan struct{}, N)` 으로 단순 확장.
+
+**결정**: **(B) 채택**. 코드 변경 최소화 + 격리 보장 + v1 이 이미 검증된 패턴.
+
+### 6.5 단계적 롤아웃 — spike → ramp-up
+
+```
+Phase 0  (release 직전): max_parallel_tasks=1 기본값 — v1.0 와 동일 동작 검증
+                          ┗ 회귀 없음 검증 (전체 e2e suite 통과 + 1주 운영)
+
+Phase 1  (spike): max_parallel_tasks=2 + 모든 task 가 같은 repo 의 dummy task
+                  ┗ "같은 repo lock" 이 정확히 직렬로 동작하는지 e2e 측정
+                  ┗ Claude CLI 2개를 fake binary 로 동시 spawn — pgid 격리, stdout 섞임 없음 검증
+                  ┗ 1일 운영 측정. 4가지 metric (성공률, crash 율, worktree 충돌, SQLite lock 에러) 모두 v1 ±5%
+
+Phase 2  (single-repo throughput 검증): max_parallel_tasks=2 + 다른 repo 의 task 혼재
+                  ┗ 실제 ~/.claude/ 동시 쓰기를 운영 환경에서 측정
+                  ┗ 1주 운영 후 metric 통과 → Phase 3 진행
+
+Phase 3  (multi-repo cap): max_parallel_tasks=3
+                  ┗ 코드의 hard cap. 운영자가 4 이상을 입력해도 3 으로 clamp
+                  ┗ 1주 운영 측정 → 안정 시 v1.1 정식 release
+```
+
+각 phase 의 통과 기준은 §9 비기능 요구사항의 "안정성" 섹션 metric 으로 정의.
+
+### 6.6 롤백 절차
+
+이슈 발생 시 다음 중 가장 빠른 경로로 즉시 직렬 모드 복귀:
+
+1. **(즉시, 재시작 X)**: 운영자가 SQLite 의 `app_states` 에 직접 `concurrency_override = {max: 1}` 를 INSERT — 다음 tick 부터 슬롯 1개만 사용. PRD §8 의 `PATCH /modes/concurrency` 도 동일 효과.
+2. **(재시작 필요)**: `config.yaml` 의 `concurrency.max_parallel_tasks: 1` 로 되돌리고 `systemctl restart scheduled-dev-agent`.
+3. **(코드 수준 kill switch)**: 환경변수 `PARALLEL_TASKS_DISABLED=1` 가 set 되어 있으면 config 와 무관하게 직렬 모드 강제 — 코드에서 가장 우선.
+
+롤백 후 다음 작업:
+- 진행 중이던 task 는 graceful shutdown 으로 drain.
+- 발생한 충돌의 root cause 분석 → 본 PRD 에 학습 사항 기록 (§12 OI 추가).
+
+## 7. 데이터 모델 (요약)
+
+기존 SQLite (`data/agent.db`) 에 마이그레이션 1개 추가. 기존 migration 수정 금지.
+
+```
+Task (변경 없음)
+  ※ status='running' 으로의 전이 race 를 막기 위한 SQL 패턴은 sqlc 쿼리로 추가
+  ※ worker_id 컬럼은 v1.1 에서 추가하지 않음 (in-memory cancelMap 으로 충분)
+
+AppState (신규 키)
+  key="concurrency_override"  value={ max: int, updated_at }
+                              ─ 0/1 → 직렬, 2~3 → 병렬, 그 외 → clamp
+                              ─ 미존재 시 config.yaml 값 사용
+```
+
+**신규 sqlc 쿼리** (`db/query/task.sql` 에 추가):
+
+```sql
+-- name: PickNextDispatchable :one
+-- 큐의 첫 task 부터 검색하되, 인메모리에서 차단된 repo 는 caller 가 다음 호출에서
+-- excluded_repos 로 전달해 스킵한다. SQL 만으로 repo lock 을 표현할 수 없으므로
+-- 락은 in-memory 가 권위 있는 출처. 본 쿼리는 단지 후보를 fetch.
+SELECT id, repo_full_name, issue_number, ...
+FROM tasks
+WHERE status = 'queued'
+  AND (sqlc.slice('excluded_repos') IS NULL
+       OR repo_full_name NOT IN (sqlc.slice('excluded_repos')))
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: ClaimTaskAtomic :execrows
+-- task 를 'queued' → 'running' 으로 atomic 전이. RowsAffected=1 이면 성공.
+-- v1.1 의 race 방지 핵심 — 두 슬롯이 같은 ID 를 pick 해도 한 쪽만 성공.
+UPDATE tasks
+SET status = 'running', updated_at = datetime('now')
+WHERE id = sqlc.arg('id') AND status = 'queued';
+```
+
+**Repo lock (in-memory)** — DB 가 아닌 코드 구조:
+
+```go
+// internal/scheduler/repolocks.go (NEW)
+type RepoLocks struct {
+    m sync.Map  // map[string]*sync.Mutex
+}
+func (r *RepoLocks) TryLock(repo string) (release func(), ok bool) { ... }
+```
+
+## 8. API 계약 (요약)
+
+신규/변경 엔드포인트:
+
+```
+GET    /modes/concurrency               현재 동시 실행 캡 + 사용 중 슬롯 수 조회
+PATCH  /modes/concurrency               { max?: int } 런타임 오버라이드 (0=config 폴백)
+GET    /healthz                         (변경) busy_slots 필드 추가
+GET    /tasks                           (변경 없음 — 직렬 시기와 동일)
+```
+
+응답 DTO:
+
+```jsonc
+// GET /modes/concurrency
+{
+  "max": 2,                    // 효과적 cap (override > config > default)
+  "config_max": 1,             // config.yaml 값
+  "override_max": 2,           // AppState 오버라이드 (없으면 0)
+  "busy_slots": 1,             // 현재 dispatch 된 task 수
+  "running_repos": ["a/b"]     // 락 잡고 있는 repo 목록 (관측용)
+}
+
+// PATCH /modes/concurrency body
+{ "max": 2 }                   // 0=config 폴백, >3 은 3 으로 clamp + warn
+
+// GET /healthz (변경)
+{
+  "status": "ok",
+  "tick_at": "...",
+  "full_mode": false,
+  "busy_slots": 1,             // NEW
+  "max_parallel_tasks": 2      // NEW
+}
+```
+
+## 9. 비기능 요구사항
+
+| 항목 | 요구 |
+|------|------|
+| 성능 | tick 한 번 안에서 N 슬롯 dispatch 가 < 200ms (SQL pickup × N + repo lock check 포함) |
+| 안정성 — 성공률 | 병렬 모드의 task 성공률 ≥ v1 직렬 모드의 ±5% (1주 측정) |
+| 안정성 — claude crash | exit_code != 0 비율 ≤ v1 직렬 모드의 ±5% |
+| 안정성 — worktree 충돌 | git worktree add 실패율 < 1% (1주 측정) |
+| 안정성 — SQLite lock 에러 | "database is locked" 발생률 < 0.1% (5s busy_timeout 후에도 실패한 경우만) |
+| 격리 | 한 슬롯의 panic / SIGKILL / OOM 이 다른 슬롯의 task status 에 영향 없음 (e2e 검증) |
+| Budget enforcement | atomic CheckAndIncrement 가 race-free (테스트: 2 goroutine 이 동시에 cap 마지막 1슬롯을 노릴 때 정확히 1개만 통과) |
+| Repo isolation | 같은 repo task 동시 dispatch = 0건 (e2e 100회 반복 측정) |
+| 보안 | 변경 없음 — 토큰·secret 노출 경로 추가 없음 |
+| 관측성 | tick 마다 `slog.Debug("scheduler: dispatch", "busy_slots", N, "max", M)`. dispatch 이벤트마다 `slot_id` payload 추가 |
+| 테스트 커버리지 | 80% (게이트). `internal/scheduler` 패키지는 **85% 이상** |
+| lint | `golangci-lint run ./...` 통과 필수 |
+| 호환성 | `max_parallel_tasks=1` (기본) 일 때 v1.0 의 동작과 **바이트 동일** — 기존 e2e suite 100% 통과 |
+
+## 10. 의존성 / 리스크
+
+**의존성**
+
+- 기존 `internal/scheduler.Scheduler` (sem 채널, cancelMap, dispatch)
+- 기존 `internal/scheduler.Worker` 의 RunTask pipeline (변경 최소화)
+- 기존 `internal/usecase.BudgetUseCase.CheckAndIncrement` (이미 mutex 보호 — race-free)
+- 기존 `internal/repository.NewDB` 의 `_journal_mode=WAL` + `MaxOpenConns(1)` 설정
+
+**리스크**
+
+- **R1 (High)**: Claude CLI 동시 실행 시 `~/.claude/sessions/` 또는 토큰 캐시 파일 충돌. 완화: ① **spike 단계에서 fake binary 로 충돌 시뮬레이션** ② 실제 운영 phase 1 에서 1일 측정 ③ 충돌 발견 시 슬롯별 `HOME=$tmpdir/claude-{slot}` 격리 (단, 이 경우 로그인 세션 분리 필요 — README 에 절차) ④ 끝까지 안전 담보 안 되면 `max=1` 영구 유지. **즉시 단정하지 말고 단계별 측정**.
+- **R2 (High)**: 같은 repo 의 두 task 가 같은 base branch 에 동시 push 시 git push 충돌 → 한 쪽 task fail. 완화: §6.2 의 in-memory repo lock 으로 같은 repo 동시 dispatch 자체를 차단 (SQL 호출 없이 코드 수준에서 걸러냄). 다른 시스템 (사람의 직접 push) 와의 충돌은 별개 — 기존 v1 의 git push rebase 1회 재시도 로직 그대로.
+- **R3 (Med)**: SQLite "database is locked" — 두 worker goroutine 이 동시에 같은 row 를 update 시도. 완화: ① `MaxOpenConns(1)` 단일 writer ② `_busy_timeout=5000` 으로 5s 대기 ③ atomic UPDATE 패턴으로 transition race 방지 ④ phase 1 에서 lock 발생률 metric 측정. 발생률 > 0.1% 이면 `max=1` 롤백.
+- **R4 (Med)**: BudgetUseCase 의 mutex 가 N 슬롯 dispatch 의 hot path 가 되어 throughput 병목. 완화: 현재 mutex 는 single-flight 를 보장할 뿐 hold time 이 매우 짧음 (수 ms 의 SQLite write). N=3 까지는 무시 가능. 측정 후 문제면 atomic counter (sql.Exec UPDATE counts SET ...) 로 전환.
+- **R5 (Low)**: `sync.Map` 의 mutex 누적 — 운영 중 repo 수 만큼 mutex pointer 가 누적. 완화: repo 수가 < 100 이라 무시 가능. v2 에서 LRU 정리 검토.
+- **R6 (Low)**: graceful shutdown 시 N 슬롯 drain time 이 30s × N 이 아니라 max 30s (병렬 drain) 가 되도록 wg.Wait + ctx cancel 설계 검증 필요.
+- **R7 (Med)**: hot-reload 미지원이므로 운영자가 config 변경 후 재시작 까먹으면 의도와 다른 동시성으로 운영. 완화: README + `/healthz` 에 `max_parallel_tasks` 노출, Slack 시작 메시지에 `slots=N` 포함.
+
+## 11. 범위 외 (Out of Scope)
+
+- 같은 repo 내 task 동시 처리 (브랜치 격리, sub-worktree 등)
+- task 우선순위 / 예약 / SLA queue
+- 분산 / 멀티 머신 실행
+- 동시성 hot-reload (config 변경 즉시 반영)
+- adaptive 동시성 (load 기반 자동 조절)
+- claude CLI 의 `--session-id` 분리 자동 관리
+- worker pool metric (Prometheus/OpenTelemetry) — 별도 PRD `usage-dashboard` 에서 다룸
+
+## 12. 오픈 이슈
+
+- [ ] **OI-1** (Phase 0 spike 결과 대기): Claude CLI 2개 동시 실행 시 `~/.claude/` 의 어느 파일이 충돌하는가? `lsof` / `strace` 로 spike 단계에서 측정. 결과에 따라 슬롯별 HOME 격리 필요 여부 결정.
+- [ ] **OI-2**: repo lock 의 mutex 가 누적되는 문제 — `sync.Map` 의 mutex pointer 를 언제 비울지. 단순화 위해 v1.1 은 비우지 않음 (운영 중 repo 수 < 100 가정). 100 이상으로 늘면 LRU 도입 검토.
+- [ ] **OI-3**: `PickNextDispatchable` 쿼리에서 excluded_repos 가 길어지면 (running_repos 가 max=3 까지 누적) IN 절 길이가 최대 3 — 무시 가능. 단, "FIFO with skip-on-conflict" 가 정말 starvation 을 일으키지 않는지 측정 필요. 같은 repo 의 task 만 여러 개 있고 다른 repo 가 없으면 슬롯이 1개만 사용됨 — 의도된 동작.
+- [ ] **OI-4**: `rate_limit_block` 발생 시 진행 중인 다른 슬롯의 task 도 즉시 cancel 할지, 자연 완료 후 다음 dispatch 만 차단할지. 상위 PRD §6.2 와 일관되게 v1.1 은 **다음 dispatch 만 차단** (현재 진행 중인 task 는 그대로). 추후 정책 변경 가능.
+- [ ] **OI-5**: graceful shutdown drain time 의 hard ceiling — max(30s × slots) 이 아닌 30s + safety margin (45s) 으로 묶을지. systemd `TimeoutStopSec` 와 일관되게 설정 필요. 기본 90s 권장.
+- [ ] **OI-6**: phase 1 spike 의 실제 수행 주체 — 본 PRD 의 구현자 (Go agent) 가 e2e 테스트 작성 + 1일 dry-run 운영까지 책임지는가, 아니면 운영자에게 인계하는가. v1.1 은 코드 + e2e 까지 구현자 책임, 운영 측정은 운영자 책임으로 분담.
+
+---
+
+## 참고 — 영향받는 파일
+
+```
+internal/
+  scheduler/
+    scheduler.go          # MOD — sem 크기 N 으로 확장, dispatch 루프, repo lock 사용
+    repolocks.go          # NEW — sync.Map 기반 per-repo TryLock
+    repolocks_test.go     # NEW
+    worker.go             # 변경 최소 (각 worker 가 동일 RunTask 그대로 사용)
+  domain/
+    repository.go         # MOD — TaskRepository 에 PickNextDispatchable, ClaimTaskAtomic 추가
+  repository/
+    task_repository.go    # MOD — 위 메서드 sqlc 호출 구현
+  usecase/
+    concurrency_usecase.go      # NEW — AppState 의 concurrency_override 관리
+    concurrency_usecase_test.go # NEW
+  api/
+    handlers_concurrency.go     # NEW — GET/PATCH /modes/concurrency
+    dto.go                      # MOD — ConcurrencyResponse, ConcurrencyPatchRequest, HealthResponse 확장
+    server.go                   # MOD — 새 라우트 등록
+
+migrations/
+  000004_add_concurrency_appstate.up.sql / .down.sql
+    (선택) AppState 키만 사용한다면 마이그레이션 불필요 — key-value 라 새 row 만 INSERT
+
+db/query/
+  task.sql                # MOD — PickNextDispatchable, ClaimTaskAtomic 쿼리 추가
+
+config.example.yaml       # MOD
+  concurrency:
+    max_parallel_tasks: 1   # 기본 1, 권장 max 3
+
+cmd/scheduled-dev-agent/main.go  # MOD — Scheduler.Config.MaxParallelTasks 주입
+
+docs/specs/parallel-tasks.md     # 본 PRD
+docs/specs/parallel-tasks/go.md  # 구현 프롬프트
+```
+
+단일 스택 프로젝트이므로 역할별 분할 없이 **단일 Go 구현 프롬프트** ([`./parallel-tasks/go.md`](./parallel-tasks/go.md)) 로 전달합니다.

--- a/docs/specs/parallel-tasks/go.md
+++ b/docs/specs/parallel-tasks/go.md
@@ -1,0 +1,387 @@
+# parallel-tasks — Go 구현 프롬프트
+
+> 이 파일은 `/planner` 가 생성한 **단일 스택(Go) 구현 지시서** 입니다.
+> 대응 PRD: [`../parallel-tasks.md`](../parallel-tasks.md)
+> 스택: **Go (Gin + GORM + sqlc + golangci-lint + swaggo)**
+> 모 PRD: [`../scheduled-dev-agent.md`](../scheduled-dev-agent.md) §3 비목표 / §10 R3 / §12 OI-2 해소
+
+---
+
+## 맥락 (꼭 읽을 것)
+
+- **PRD 본문**: `docs/specs/parallel-tasks.md`
+- **모 PRD**: `docs/specs/scheduled-dev-agent.md` (전체 시스템 흐름)
+- **스택 규칙 (최우선)**: 프로젝트 루트 `CLAUDE.md` — Go Gin 기반, MUST/NEVER, sqlc, golangci-lint, swag, 커버리지 80%
+- **관련 패턴 스킬**: `.claude/skills/go-patterns.md`, `.claude/skills/api-design-patterns.md` (있으면)
+- **외부 도구**: `claude` CLI (병렬 실행 충돌 spike 대상), `gh` CLI, `git`
+
+**스택의 절대 규칙 (CLAUDE.md 요약 — 충돌 시 CLAUDE.md 우선)**
+- `domain/` 패키지는 외부 패키지 import 금지 (GORM, gin 불가)
+- 레이어 방향: `handler → usecase → domain ← repository`
+- 복잡 쿼리 / 조건 검색은 **sqlc 필수**. 단순 CRUD 만 GORM.
+- 모든 Handler 에 swag 주석 필수. Request/Response DTO 에 `example:"..."` 태그 필수.
+- `context.Context` 전 레이어 전파. 요청 핸들러는 `c.Request.Context()` 사용.
+- 전역 DB 변수 금지. DI 는 생성자 파라미터로만.
+- 기존 migration 수정 금지 — 새 파일만.
+- 토큰 / PAT / Slack secret / PII 로그 금지.
+- 복구 가능한 에러에 `panic()` 금지 (단, 본 PRD 에서는 worker goroutine 의 top-level `recover()` 가 격리 보장 목적이라 허용).
+
+---
+
+## 이 프로젝트의 책임 범위 (전체)
+
+단일 스택이므로 PRD 전체를 이 프롬프트가 커버합니다.
+
+- **포함**:
+  - `internal/scheduler` 의 dispatch 로직을 N 슬롯으로 확장 (sem 크기 변경 + repo lock)
+  - per-repo in-memory mutex (`RepoLocks`) 신규 패키지
+  - sqlc 쿼리 2개 추가 (`PickNextDispatchable`, `ClaimTaskAtomic`) + Repository 메서드
+  - `ConcurrencyUseCase` (AppState 기반 runtime override + clamp 정책)
+  - `/modes/concurrency` GET/PATCH 핸들러 + DTO + swag 주석
+  - `/healthz` 응답 확장 (`busy_slots`, `max_parallel_tasks`)
+  - config 확장: `concurrency.max_parallel_tasks` (기본 1, 최대 3 clamp)
+  - 단위 / e2e 테스트 (race 시뮬레이션, repo lock 격리, 격리 검증)
+  - kill switch 환경변수 (`PARALLEL_TASKS_DISABLED=1`)
+
+- **제외 (PRD §3 비목표)**:
+  - 같은 repo 내 task 동시 처리
+  - 분산 / 멀티 머신
+  - hot-reload (config 변경 즉시 반영)
+  - claude CLI HOME 격리 자동화 — spike 결과에 따라 별도 PRD 로 분기
+  - metric 노출 (Prometheus/OTel)
+
+---
+
+## 변경할/생성할 파일 (체크리스트)
+
+> 모든 경로는 프로젝트 루트 기준. 단계별로 PRD §6.5 의 phase 0 (max=1, v1 동작 동일) → phase 1+ (병렬) 가 한 release 안에 들어갑니다.
+
+### 1. Config
+
+- [ ] `internal/config/config.go` — `ConcurrencyConfig{ MaxParallelTasks int }` 추가, `Config.Concurrency` 필드, viper default = `1`
+- [ ] `internal/config/validate.go` — `MaxParallelTasks < 0` reject, `> 3` 일 때 `3` 으로 clamp + `slog.Warn`
+- [ ] `internal/config/config_test.go` — 음수 / 0 / 1 / 2 / 3 / 4 (clamp 검증) / 누락 (default=1)
+- [ ] `config.example.yaml` 에 `concurrency.max_parallel_tasks: 1` 섹션 추가 + 주석 (권장 최대 3)
+
+### 2. Domain
+
+- [ ] `internal/domain/repository.go` — `TaskRepository` 인터페이스에 다음 추가:
+  ```go
+  // PickNextDispatchable returns the oldest queued task whose repo is NOT in
+  // excludedRepos. Returns ErrNotFound when no candidate exists.
+  PickNextDispatchable(ctx context.Context, excludedRepos []string) (*Task, error)
+
+  // ClaimTask atomically transitions a task from 'queued' to 'running'.
+  // Returns true iff RowsAffected == 1 (this caller won the race).
+  ClaimTask(ctx context.Context, id string) (bool, error)
+  ```
+- [ ] `domain/` 외부 import 금지 규칙 준수 — 위 메서드 시그니처는 표준 `context` 외 의존 없음
+
+### 3. Migrations
+
+본 PRD 는 **신규 컬럼 추가가 없음**. AppState 의 새 키 (`concurrency_override`) 만 사용.
+
+- [ ] (스킵) 마이그레이션 파일 생성하지 않음 — 기존 `app_states` 테이블에 key 만 INSERT
+- [ ] (대안) 만약 기존 task 가 `status='running'` 상태로 orphan 되어 있을 때 starvation 가능성을 막기 위해 startup 시 한 번만 `UPDATE tasks SET status='failed' WHERE status='running' AND started_at < (now - 1h)` 보정 — 이미 모 PRD §6.2 의 orphan 처리에 포함됨 → 추가 작업 없음
+
+### 4. Repository (sqlc + GORM)
+
+- [ ] `db/query/task.sql` — 다음 두 쿼리 추가 (raw SQL 금지 규칙 준수, sqlc generate 필수):
+  ```sql
+  -- name: PickNextDispatchable :one
+  SELECT id, repo_full_name, issue_number, issue_title, task_type, status,
+         prompt_template, worktree_path, pr_url, pr_number,
+         started_at, finished_at,
+         estimated_input_tokens, estimated_output_tokens,
+         exit_code, stderr_tail, created_at, updated_at
+  FROM tasks
+  WHERE status = 'queued'
+    AND repo_full_name NOT IN (sqlc.slice('excluded_repos'))
+  ORDER BY created_at ASC
+  LIMIT 1;
+
+  -- name: ClaimTask :execrows
+  UPDATE tasks
+  SET status = 'running', updated_at = datetime('now')
+  WHERE id = sqlc.arg('id') AND status = 'queued';
+  ```
+  - **주의**: sqlc 의 `sqlc.slice` 는 SQLite 에서 빈 배열 처리 시 placeholder 가 0개라 syntax error 가능 — caller 가 빈 slice 를 전달할 경우 `repo_full_name NOT IN ('')` 가 되도록 dummy `""` 를 항상 1개 prepend 하거나, 두 가지 쿼리 (`PickNextDispatchableAll` / `PickNextDispatchableExcluding`) 로 분기
+- [ ] `sqlc.yaml` 변경 없음 (이미 `db/query/`, `db/sqlc/` 설정)
+- [ ] **`sqlc generate` 필수 실행** — `db/sqlc/` 코드 자동 생성. 수동 수정 금지
+- [ ] `internal/repository/task_repository.go`
+  - `PickNextDispatchable(ctx, excludedRepos []string) (*domain.Task, error)` 구현
+    - sqlc 호출 → `gormTask` 동등 변환 → `toDomainTask`
+    - 결과 없음 → `domain.ErrNotFound`
+  - `ClaimTask(ctx, id string) (bool, error)` 구현
+    - sqlc `:execrows` 결과 → `rows == 1`
+- [ ] `internal/repository/sqlite_test.go` 또는 신규 `task_repository_dispatch_test.go`
+  - 두 goroutine 이 같은 `id` 로 동시 `ClaimTask` → 정확히 1개만 `true` (race-free 검증)
+  - `PickNextDispatchable(ctx, []string{"a/b"})` → repo 'a/b' task 가 있으면 그 다음 task 반환
+  - 빈 slice 전달 시 정상 동작 (sqlc.slice 빈 처리 검증)
+
+### 5. RepoLocks (신규 패키지)
+
+- [ ] `internal/scheduler/repolocks.go`
+  ```go
+  // RepoLocks tracks per-repo mutexes for serialising same-repo task dispatch.
+  // The zero value is ready to use.
+  type RepoLocks struct {
+      m sync.Map  // string -> *sync.Mutex
+  }
+
+  // TryLock attempts to acquire the lock for repo without blocking.
+  // Returns release fn (always non-nil) and ok=false if the lock is held.
+  func (r *RepoLocks) TryLock(repo string) (release func(), ok bool) { ... }
+
+  // HeldRepos returns a snapshot of repos currently locked. For observability
+  // (e.g. /modes/concurrency response). Order is not guaranteed.
+  func (r *RepoLocks) HeldRepos() []string { ... }
+  ```
+  - 구현: `sync.Map.LoadOrStore` 로 mutex 포인터 확보 → `mu.TryLock()` (Go 1.18+) → release 는 `mu.Unlock()`
+  - `HeldRepos` 는 `sync.Map.Range` 로 `mu.TryLock` 시도해 잡혀 있던 것만 수집 후 즉시 해제 (관측용 — 정확성보다 가시성 우선)
+- [ ] `internal/scheduler/repolocks_test.go`
+  - 같은 repo 두 번 `TryLock` → 두 번째 `ok=false`
+  - release 후 다시 `TryLock` → 성공
+  - 다른 repo 두 개 → 둘 다 성공 (격리)
+  - 100 goroutine 동시 `TryLock` 같은 repo → 정확히 1개 성공
+
+### 6. Scheduler 확장
+
+- [ ] `internal/scheduler/scheduler.go`
+  - `Config` 에 `MaxParallelTasks int` 추가
+  - `Scheduler.sem` 크기를 `MaxParallelTasks` 로 (clamp: `0/1 → 1`, `>3 → 3`)
+  - `Scheduler.repoLocks *RepoLocks` 필드 추가
+  - `Scheduler.concurrencyOverride func() int` 필드 (런타임 override 조회 — `ConcurrencyUseCase.EffectiveMax` 주입)
+  - `tick()` 에서 dispatch 루프 N 회:
+    ```
+    for slot := 0; slot < effectiveMax; slot++ {
+        if !s.tryAcquireSlot() { break }
+        if !s.dispatch(ctx) { s.releaseSlot(); break }
+    }
+    ```
+  - `dispatch(ctx)` 변경:
+    - `repoLocks.HeldRepos()` 호출해 `excludedRepos` 산출
+    - `taskRepo.PickNextDispatchable(ctx, excludedRepos)` 호출
+    - `repoLocks.TryLock(task.RepoFullName)` 시도. 실패하면 false return (다음 slot 도 시도 가능)
+    - `taskRepo.ClaimTask(ctx, task.ID)` 호출. `false` (이미 다른 슬롯이 가져갔거나 status 가 queued 가 아님) 면 release lock + false return
+    - 성공 시 `cancelMap[task.ID] = cancel`, `wg.Add(1)` 후 worker goroutine spawn
+    - worker goroutine 의 `defer` 체인에서 sem 반납 + repo lock release + cancelMap 삭제
+  - `cancelMap` 보호: 기존 `sync.Mutex` 그대로 유지 — N 슬롯에서도 안전
+  - **`recover()` 추가**: worker goroutine 의 top-level 에서 panic 격리:
+    ```go
+    defer func() {
+        if r := recover(); r != nil {
+            slog.Error("scheduler: worker panic", "task_id", task.ID, "panic", r, "stack", string(debug.Stack()))
+        }
+    }()
+    ```
+- [ ] **kill switch**: `os.Getenv("PARALLEL_TASKS_DISABLED") == "1"` 이면 `effectiveMax = 1` 강제 (config / override 무시)
+- [ ] `internal/scheduler/scheduler_test.go`
+  - max=1 일 때 sem 크기 1, dispatch 루프 1회 (v1 회귀)
+  - max=2 일 때 두 다른 repo task → 동시 dispatch 검증 (두 worker 의 RunTask 가 동시에 호출됨 — `time.Now()` 차이 < 200ms)
+  - max=2 일 때 같은 repo task 두 개 → 한 번에 한 개만 dispatch
+  - max=3 일 때 worker panic → 다른 슬롯 영향 없음 (recover 검증)
+  - max=4 입력 → 3 으로 clamp + warn 로그
+  - `PARALLEL_TASKS_DISABLED=1` → max=1 강제
+
+### 7. Worker (변경 최소)
+
+- [ ] `internal/scheduler/worker.go` — **변경 없음** 이 원칙. 단:
+  - `RunTask` 내부에서 budget gate 의 `CheckAndIncrementReason` 가 race-free 인지 재확인 (이미 mutex 보호)
+  - `provisionWorktree` 의 worktree 경로가 task ID 기반 (`.worktrees/task-{id}`) 이라 N 슬롯에서도 충돌 없음 (검증만)
+- [ ] worker_test.go 에 e2e 시나리오 추가:
+  - 두 task 가 RunTask 를 동시에 실행해도 Slack notify, TaskEvent 기록, BudgetUseCase increment 가 모두 race-free
+
+### 8. ConcurrencyUseCase (신규)
+
+- [ ] `internal/usecase/concurrency_usecase.go`
+  ```go
+  type ConcurrencyUseCase struct {
+      appStateRepo domain.AppStateRepository
+      configMax    int
+      mu           sync.Mutex
+  }
+
+  // EffectiveMax returns the runtime cap, applying override > config > default
+  // and the [0..3] clamp. Reads from AppState every call (cheap — single SQL).
+  func (uc *ConcurrencyUseCase) EffectiveMax(ctx context.Context) int { ... }
+
+  // SetOverride persists a runtime override. max=0 falls back to config.
+  func (uc *ConcurrencyUseCase) SetOverride(ctx context.Context, max int) (int, error) { ... }
+
+  // Snapshot returns config + override + effective for /modes/concurrency.
+  func (uc *ConcurrencyUseCase) Snapshot(ctx context.Context) ConcurrencySnapshot { ... }
+  ```
+- [ ] AppState key: `"concurrency_override"`, value JSON: `{"max": int, "updated_at": unix}`
+- [ ] clamp 정책 한 곳에 — `clamp(n int) int { if n < 0 { return 0 }; if n > 3 { return 3 }; return n }`
+- [ ] `internal/usecase/concurrency_usecase_test.go`
+  - override 없으면 config 값 반환
+  - override=2, config=1 → 2
+  - override=4 → 3 (clamp + warn 로그 검증)
+  - override=0 → config 폴백
+  - `PARALLEL_TASKS_DISABLED=1` 우선 (선택 — env 검사를 UseCase 가 아닌 Scheduler 단에서만 한다면 스킵)
+
+### 9. API Handler
+
+- [ ] `internal/api/dto.go` 추가:
+  ```go
+  // ConcurrencyResponse is the response for GET /modes/concurrency.
+  type ConcurrencyResponse struct {
+      Max          int      `json:"max" example:"2"`
+      ConfigMax    int      `json:"config_max" example:"1"`
+      OverrideMax  int      `json:"override_max" example:"2"`
+      BusySlots    int      `json:"busy_slots" example:"1"`
+      RunningRepos []string `json:"running_repos" example:"owner/repo"`
+  }
+
+  // ConcurrencyPatchRequest is the body for PATCH /modes/concurrency.
+  // max=0 falls back to the config value. Values >3 are clamped to 3.
+  type ConcurrencyPatchRequest struct {
+      Max int `json:"max" example:"2"`
+  }
+  ```
+- [ ] `internal/api/dto.go` `HealthResponse` 확장:
+  ```go
+  BusySlots         int `json:"busy_slots" example:"1"`
+  MaxParallelTasks  int `json:"max_parallel_tasks" example:"2"`
+  ```
+- [ ] `internal/api/handlers_concurrency.go` (신규)
+  - `GET /modes/concurrency` — swag `@Tags modes`, `@Router /modes/concurrency [get]`, `@Success 200 {object} ConcurrencyResponse`
+  - `PATCH /modes/concurrency` — `@Failure 400 {object} ErrorResponse`, body validation (음수 reject)
+- [ ] `internal/api/server.go` (또는 router 등록 위치) — 위 두 라우트 추가
+- [ ] healthz 핸들러에 `busy_slots`, `max_parallel_tasks` 채우는 의존성 주입 (`Scheduler.Stats() (busy, max int)` 같은 메서드 추가 검토)
+- [ ] `internal/api/handler_test.go` 에 두 엔드포인트 테스트 (성공 / clamp / override=0 폴백 / 음수 reject)
+
+### 10. main.go DI
+
+- [ ] `cmd/scheduled-dev-agent/main.go`
+  - `cfg.Concurrency.MaxParallelTasks` 읽어 `scheduler.Config.MaxParallelTasks` 로 전달
+  - `ConcurrencyUseCase` 생성 → Scheduler 의 `concurrencyOverride` 함수 어댑터로 주입
+  - kill switch 환경변수 검사를 main 또는 Scheduler 생성자 한 곳에서
+  - swag 주석 갱신 — 새 endpoint 가 자동 픽업되는지 `swag init -g cmd/scheduled-dev-agent/main.go -o docs` 실행
+
+### 11. Tests
+
+#### 단위 테스트 (커버리지 ≥ 85% — scheduler 패키지)
+
+- [ ] `RepoLocks` — 100 goroutine race
+- [ ] `ClaimTask` — 두 동시 호출 → 1개만 true (sqlite_test.go 에 추가)
+- [ ] `PickNextDispatchable` — excluded_repos 빈 / 1개 / 3개 케이스
+- [ ] `ConcurrencyUseCase.EffectiveMax` — 모든 분기
+- [ ] config validate — `MaxParallelTasks` 음수 / 0 / 1 / 4 / clamp
+
+#### 통합 / e2e
+
+- [ ] `internal/scheduler/scheduler_test.go` (또는 별도 `parallel_e2e_test.go`)
+  - **시나리오 1 — 다른 repo 동시 dispatch**: max=2, queue=[task-A(repoX), task-B(repoY)] → 200ms 안에 두 worker 모두 RunTask 진입
+  - **시나리오 2 — 같은 repo 직렬화**: max=2, queue=[task-A(repoX), task-B(repoX), task-C(repoY)] → A + C 동시, B 는 A 완료 후
+  - **시나리오 3 — 격리 (panic)**: max=2 worker 1 패닉 → worker 2 정상 완료 + scheduler 살아있음
+  - **시나리오 4 — budget race**: max=2, daily_cap=1 (마지막 1슬롯) → 두 worker 가 동시 CheckAndIncrement → 1개 성공, 1개 cancel
+  - **시나리오 5 — graceful shutdown**: max=3, 3 worker 진행 중 Stop() → 모두 SIGTERM, 30s 안에 wg.Wait 완료
+  - **시나리오 6 — kill switch**: `PARALLEL_TASKS_DISABLED=1` 환경에서 max=3 config → 실제 sem 크기 1
+- [ ] `mocks/` — `mockery --name=TaskRepository --dir=internal/domain --output=mocks` 재생성
+
+#### 회귀 (v1 동작 동일)
+
+- [ ] max=1 일 때 기존 e2e suite 100% 통과 (PRD G6)
+
+### 12. Swag / Lint / Coverage
+
+- [ ] `swag init -g cmd/scheduled-dev-agent/main.go -o docs` 재실행 — `/modes/concurrency` 가 Swagger UI 에 노출되는지 확인
+- [ ] `golangci-lint run ./...` 통과 (모든 신규 파일에 `// Package ...` doc comment, exported 식별자 doc comment 필수)
+- [ ] `go test ./... -coverprofile=cover.out` → 전체 80% 이상, `internal/scheduler` ≥ 85%
+- [ ] `.claude/hooks/pre-push.sh` 통과 (커버리지 + lint 게이트)
+
+### 13. Docs / Config / README
+
+- [ ] `config.example.yaml`
+  ```yaml
+  concurrency:
+    # 동시 실행 슬롯 수. 기본 1 (직렬 — v1.0 동작과 동일).
+    # 권장 최대 3. 4 이상은 자동으로 3 으로 clamp 됩니다.
+    # PRD docs/specs/parallel-tasks.md §6.5 의 단계적 ramp-up 절차 참조.
+    max_parallel_tasks: 1
+  ```
+- [ ] `README.md` 또는 `docs/operations.md` — kill switch (`PARALLEL_TASKS_DISABLED=1`), 단계적 ramp-up 절차, 롤백 절차 (PRD §6.6) 명시
+- [ ] CHANGELOG / release notes (이 repo 가 `release-please` 사용 — `feat(scheduler): support N parallel tasks` 형태 commit)
+
+---
+
+## 구현 제약 (스택 CLAUDE.md 준수)
+
+이 역할의 `CLAUDE.md` 규칙이 본 프롬프트보다 우선합니다. 다음 항목을 특히 주의:
+
+- [ ] **DI**: 생성자 파라미터 주입만. `ConcurrencyUseCase` 와 `Scheduler` 모두 `New(...)` 에서 의존성 받음. 전역 변수 금지
+- [ ] **에러**: `fmt.Errorf("...: %w", err)` 로 wrap. `gorm.ErrRecordNotFound` → `domain.ErrNotFound` 변환은 기존 패턴 그대로
+- [ ] **context**: `PickNextDispatchable`, `ClaimTask` 모두 `ctx` 첫 인자. handler 는 `c.Request.Context()` 사용
+- [ ] **Handler 응답**: domain error → HTTP status (404 / 400 / 500). 내부 에러 메시지 노출 금지
+- [ ] **sqlc**: 신규 쿼리 두 개는 sqlc 로 작성. raw SQL 문자열 (GORM `Raw`) 금지
+- [ ] **swag**: 새 endpoint 모두 `@Summary @Tags @Router @Success @Failure` 작성. DTO 에 `example:"..."` 태그
+- [ ] **domain/ 외부 import 금지**: `TaskRepository` 인터페이스에 `context` 외 의존 없음. mutex / sync.Map 같은 구현 디테일은 repository 레이어
+- [ ] **panic 금지** — 단, worker goroutine top-level `defer recover()` 는 격리 보장 목적이라 허용. 그 외 호출 경로에서는 절대 panic 사용 X
+- [ ] **기존 migration 수정 금지** — 본 PRD 는 마이그레이션 추가 없음 (AppState key 만 사용)
+- [ ] **`db/sqlc/` 수동 수정 금지** — `sqlc generate` 로 재생성
+
+---
+
+## 다른 시스템과의 계약 (Interface)
+
+- **Scheduler ↔ ConcurrencyUseCase**:
+  - Scheduler 는 매 tick 마다 `concurrencyOverride()` 호출 → 효과적 max 반환
+  - 변경 시 Scheduler 는 다음 tick 부터 새 값 사용 (현재 진행 중 슬롯은 그대로 drain)
+- **Scheduler ↔ TaskRepository**:
+  - `PickNextDispatchable(ctx, excludedRepos)` → 후보 1개 또는 `ErrNotFound`
+  - `ClaimTask(ctx, id)` → atomic queued→running 전이. `false` 는 race 패배
+- **API ↔ ConcurrencyUseCase**:
+  - GET `/modes/concurrency` → `Snapshot()` 호출
+  - PATCH `/modes/concurrency` → `SetOverride(ctx, max)` 호출. Scheduler 는 polling 방식이라 즉시 반영
+
+계약 변경 시 PRD §8 의 "API 계약" 섹션을 먼저 갱신.
+
+---
+
+## 실행 지시
+
+이 프롬프트를 받은 agent 는 아래 순서로 진행:
+
+1. 프로젝트 루트 `CLAUDE.md` 와 `docs/specs/parallel-tasks.md`, `docs/specs/scheduled-dev-agent.md` 를 먼저 읽기
+2. 기존 코드 탐색 — `internal/scheduler/scheduler.go`, `internal/scheduler/worker.go`, `internal/repository/task_repository.go`, `internal/usecase/budget_usecase.go`, `internal/api/dto.go` 패턴 파악
+3. 위 체크리스트의 **필요한 항목만** 생성. 마이그레이션은 추가하지 않음
+4. **파일 생성 순서** (의존성 그래프 따라):
+   1. `db/query/task.sql` 쿼리 추가 → `sqlc generate`
+   2. `internal/domain/repository.go` 인터페이스 확장
+   3. `internal/repository/task_repository.go` 구현
+   4. `internal/scheduler/repolocks.go` 신규
+   5. `internal/usecase/concurrency_usecase.go` 신규
+   6. `internal/scheduler/scheduler.go` 확장
+   7. `internal/api/dto.go` 확장 + `handlers_concurrency.go` 신규 + `server.go` 라우트 등록
+   8. `internal/config/config.go`, `validate.go`, `config.example.yaml`
+   9. `cmd/scheduled-dev-agent/main.go` DI 조립
+   10. 모든 단위 / e2e 테스트
+   11. `swag init`, `golangci-lint run`, 커버리지 측정
+5. 생성 완료 후 요약 리포트:
+   - 생성된 파일 목록
+   - 변경된 기존 파일 목록
+   - 추가된 sqlc 쿼리 (재생성된 `db/sqlc/` 파일 목록 포함)
+   - swag init 결과 (Swagger UI 의 새 endpoint 확인)
+   - 커버리지 % (전체 + scheduler 패키지)
+   - **단계적 ramp-up 안내**: 운영자가 첫 release 후 `max_parallel_tasks=1` 로 1주 운영 → phase 1 spike 전환 절차 (PRD §6.5)
+
+---
+
+## 성공 기준
+
+- [ ] 위 체크리스트 모든 항목 체크됨 (마이그레이션 항목은 명시적 스킵 OK)
+- [ ] `go test ./...` 전체 통과
+- [ ] 커버리지: 전체 ≥ 80%, `internal/scheduler` ≥ 85%
+- [ ] `golangci-lint run ./...` 통과
+- [ ] `swag init` 성공, Swagger UI 에 `/modes/concurrency` GET/PATCH + 확장된 `/healthz` 노출
+- [ ] **회귀 검증**: `max_parallel_tasks=1` 로 설정 시 기존 e2e suite 100% 통과 (v1.0 동작 바이트 동일)
+- [ ] **race 검증**: e2e 시나리오 1~6 통과
+- [ ] CLAUDE.md 의 MUST / NEVER 위반 0건
+- [ ] kill switch (`PARALLEL_TASKS_DISABLED=1`) 동작 확인
+- [ ] PRD §6.5 의 phase 0 acceptance 통과 (max=1 1주 운영 가능 상태)
+
+---
+
+> 이 프롬프트는 `/planner` 가 자동 생성했습니다. PRD 변경이 발생하면 이 파일도 함께 갱신하세요.

--- a/docs/specs/pr-reviewer-assign.md
+++ b/docs/specs/pr-reviewer-assign.md
@@ -1,0 +1,238 @@
+# PRD — pr-reviewer-assign
+
+| 항목 | 값 |
+|------|-----|
+| 작성일 | 2026-04-27 |
+| 상태 | draft |
+| 스택 범위 | Go (단일 바이너리 — `internal/github/`, `internal/config/`) |
+| 우선순위 | P1 |
+| 작성자 | gs97ahn@gmail.com |
+| 부모 PRD | [`./scheduled-dev-agent.md`](./scheduled-dev-agent.md) (§5 US-2, §12 OI-3 해소 항목) |
+
+---
+
+## 1. 배경
+
+현재 `internal/github/pr_creator.go` 는 PR 생성 시 `config.RepoConfig.Reviewers` 배열을 그대로 `gh pr create --reviewer` 플래그에 펼친다. 운영자가 매 레포마다 reviewer 를 수동 나열해야 하므로 **CODEOWNERS 가 이미 정의된 레포에서는 정보가 이중관리** 되고, **이슈에 assignee 를 지정해도 PR 에 자동 전달되지 않는다**.
+
+부모 PRD 의 OI-3 ("PR reviewer 자동 할당 규칙") 가 미해소 상태였고 이번에 다음 정책으로 확정한다:
+
+1. **`config.repos[].reviewers`** — 명시적 선언이 가장 신뢰도 높음 (1순위)
+2. **CODEOWNERS** — 변경 파일 경로 매칭으로 자동 도출 (2순위)
+3. **이슈 assignee 상속** — 옵션 (3순위, 기본 비활성)
+
+이슈 → PR 자동화에서 reviewer 누락은 머지 지연 / 잘못된 사람에게 알림 가는 문제로 이어진다. 이 기능은 `config` 와 GitHub 메타데이터를 결합하여 **운영자 추가 입력 없이** 적절한 reviewer 를 결정한다.
+
+## 2. 목표 (Goals)
+
+- G1. `repos[].reviewers` 만 설정된 기존 레포는 **기존 동작과 100% 동일** (회귀 0건)
+- G2. CODEOWNERS 가 있는 레포는 **변경된 파일들의 owner 합집합** 을 자동 reviewer 로 추가 (mode=merge) 또는 단독 사용 (mode=codeowners-only)
+- G3. `inherit_issue_assignee: true` 인 레포는 이슈 assignee 도 reviewer 후보에 포함
+- G4. **PR 생성 자체는 reviewer 할당 실패와 독립** — reviewer 단계 에러는 warning 로그 + Slack `:warning:` 통지 후 PR URL 정상 반환
+- G5. **자기 자신** (`gh` 가 거부) 또는 **빈 후보** 는 자동 제외, 남은 후보만 `--reviewer` 로 전달
+- G6. **팀 reviewer** (`@org/team-name`) 는 user 와 동일하게 처리 (CODEOWNERS 의 `@org/team` 표기 보존)
+- G7. CODEOWNERS 조회 1회당 GitHub API 호출 ≤ 1회 (PR 생성당). 캐시 TTL 60초 (메모리 LRU, 레포별)
+
+## 3. 비목표 (Non-goals)
+
+- CODEOWNERS 의 **고급 기능** (브랜치별 CODEOWNERS, 와일드카드 우선순위 정밀 재현) — v1 은 GitHub 의 단순 매칭 규칙 (마지막 매치 우선) 만 지원
+- reviewer 가 **PR 머지 정책에 미치는 영향** (required reviewer protection 등) 변경 — 이 PRD 는 PR 생성 시 할당까지만 책임
+- `gh pr edit --add-reviewer` 사후 보정 경로 — v1 은 `gh pr create --reviewer` 한 번에 처리. 실패 시 재시도 없이 warning
+- 사용자가 **PR 머지 후** reviewer 통계 분석 / 자동 rotation
+- GitLab / Bitbucket 의 동등 기능
+
+## 4. 대상 사용자
+
+- **Solo developer (P1)** — 부모 PRD 동일. 자기 레포는 단독 owner 라 사실상 reviewer 자동 할당이 불필요하지만 **다른 사람의 레포에 기여하는 경우** CODEOWNERS 자동 매칭이 가치 발생
+- **Small team lead (P2)** — 부모 PRD 의 핵심 수혜자. CODEOWNERS 가 이미 정의된 팀 레포에서 config 중복 제거
+
+권한: 별도 권한 변경 없음. 기존 `GITHUB_TOKEN` 으로 contents 읽기 (CODEOWNERS 파일 fetch) + PR 작성 가능해야 함.
+
+## 5. 유저 스토리
+
+| # | 스토리 | 수락 기준 |
+|---|--------|-----------|
+| US-1 | 운영자로서 **`repos[].reviewers` 만으로** 기존처럼 reviewer 할당이 동작하길 원한다 | 1) 신규 옵션을 모두 빈 값으로 두면 기존 v0 동작과 바이트 단위로 동일한 `gh pr create` args 생성 <br> 2) 기존 `pr_creator_test` 회귀 테스트 통과 (테스트 신규 추가 포함) |
+| US-2 | 운영자로서 **CODEOWNERS 만 사용** 하는 모드를 켜고 싶다 | 1) `repos[].reviewer_strategy: "codeowners-only"` 로 선언 <br> 2) PR 생성 직전 변경 파일 목록(`git diff --name-only` 또는 worktree 의 staged files) 으로 CODEOWNERS 매칭 → user/team 합집합 산출 <br> 3) 매치된 owner 가 0명이면 reviewer 미지정으로 PR 생성 (warning 로그) <br> 4) `repos[].reviewers` 가 함께 설정되어 있어도 무시 (codeowners-only) |
+| US-3 | 운영자로서 **config 우선 + CODEOWNERS 보완** (merge) 모드를 쓰고 싶다 | 1) `repos[].reviewer_strategy: "merge"` 로 선언 <br> 2) 후보 = `repos[].reviewers` ∪ CODEOWNERS_owners <br> 3) 중복 제거 (대소문자 무시 비교, 출력은 첫 등장 형태 유지) <br> 4) 최종 후보 수 > 15 면 앞에서부터 15명 cut + warning 로그 (gh CLI 한도) |
+| US-4 | 운영자로서 **이슈 assignee 도 reviewer 로 상속** 하길 원한다 (옵션) | 1) `repos[].inherit_issue_assignee: true` 로 선언 (기본 false) <br> 2) 폴러가 task 생성 시 issue.assignees 를 task 메타에 저장 → PR 생성 단계에서 후보에 합집합 추가 <br> 3) `reviewer_strategy` 와 직교 — 어느 strategy 든 옵션 적용 가능 <br> 4) assignee 가 PR author (claude-ops 봇 자신) 와 동일하면 자동 제외 |
+| US-5 | 운영자로서 **자기 자신·잘못된 user** 가 후보에 들어가도 PR 생성이 깨지지 않길 원한다 | 1) 후보 sanitize: PR author (config 의 `github.actor` 또는 `gh api user` 결과) 를 후보에서 제거 <br> 2) `gh pr create --reviewer` 가 일부 user 를 거부해도 (`Could not request reviewer`) 다른 user 는 할당된 채로 PR 자체는 생성 <br> 3) 거부된 user 목록을 `TaskEvent{kind=reviewer_warning, payload={rejected:[...]}}` 로 기록 <br> 4) Slack 알림에 `reviewers assigned (warnings: N)` 형태로 합산 표기 |
+| US-6 | 운영자로서 **팀 reviewer** (`@org/team`) 도 동일하게 다뤄지길 원한다 | 1) CODEOWNERS 의 `@org/team-name` 항목은 형태 그대로 유지하여 `gh pr create --reviewer org/team-name` 로 전달 (gh CLI 는 prefix `@` 없이 받음) <br> 2) `repos[].reviewers` 에서도 `org/team` 형태 허용 <br> 3) `/` 포함 여부로 user/team 자동 판별 |
+| US-7 | 운영자로서 **CODEOWNERS 가 없는 레포** 에서 silently 동작하길 원한다 | 1) GitHub API 가 404 (CODEOWNERS 미존재) 반환 시 ErrCodeownersNotFound 로 변환 → 빈 owner 목록 + slog.Debug 1줄 (에러 아님) <br> 2) `merge` 모드에선 그대로 `repos[].reviewers` 만 사용 <br> 3) `codeowners-only` 모드에선 reviewer 미지정으로 PR 생성 + warning 로그 |
+| US-8 | 운영자로서 **CODEOWNERS 조회 캐시** 로 GitHub API 호출이 폭증하지 않길 원한다 | 1) 레포별 메모리 LRU (entries=64, TTL=60s) <br> 2) 60초 내 재조회는 캐시 히트 (slog.Debug 로그) <br> 3) ETag 기반 conditional GET 까지는 v1 범위 외 (단순 TTL) |
+
+## 6. 핵심 플로우
+
+### 6.1 행복 경로 — merge 모드 (기본 권장)
+
+```
+1. Worker.createPR(ctx, task) 호출 (기존)
+2. PRCreator.CreatePR 가 git add + commit + push 까지 완료 (기존)
+3. → ReviewerResolver.Resolve(ctx, task, worktreePath, repoCfg) 신규
+   3a. changedFiles = git diff --name-only origin/{base}..HEAD (worktree 에서 실행)
+   3b. switch repoCfg.ReviewerStrategy {
+         case "config-only" or "":  candidates = repoCfg.Reviewers
+         case "codeowners-only":    candidates = codeownersFor(changedFiles)
+         case "merge":              candidates = union(repoCfg.Reviewers, codeownersFor(changedFiles))
+       }
+   3c. if repoCfg.InheritIssueAssignee: candidates ∪= task.IssueAssignees
+   3d. candidates = sanitize(candidates) — self 제외, 중복 제거, > 15 면 앞 15
+4. ghArgs = [...] + flatten("--reviewer", candidates)
+5. prURL, _ := gh.RunGh(ctx, ghArgs...)
+6. if err 가 partial reject (PR 은 생성되었으나 일부 reviewer 실패):
+     parsed = parseGhRejectedReviewers(err.message)
+     TaskEvent(kind=reviewer_warning, payload={rejected: parsed})
+     Slack NotifyReviewerWarning(task, parsed)
+     return prURL, prNum, nil  // PR 자체는 성공
+7. return prURL, prNum, nil
+```
+
+### 6.2 예외 경로
+
+- **CODEOWNERS 미존재**: `gh api repos/{repo}/contents/.github/CODEOWNERS` 가 404 → 빈 set 반환. `merge` 모드는 config 만, `codeowners-only` 는 reviewer 미지정 + warning.
+- **CODEOWNERS 조회 실패** (네트워크/5xx): 에러 1회 재시도 (250ms backoff) → 여전히 실패 시 빈 set 으로 degrade + slog.Warn. PR 생성은 진행.
+- **gh CLI 가 reviewer 단계에서만 실패** (PR 은 생성됨): `gh pr create` 가 `--reviewer` 일부 거부 시 stderr 에 `request_failed for reviewer X` 메시지 + non-zero exit 가능. 현재 구현은 전체 실패로 보지만, 본 PRD 에서는 stderr 패턴 매칭으로 **PR URL 추출 성공 시 부분 실패로 분류**.
+- **changedFiles 추출 실패** (worktree 가 이미 정리되었거나 git 명령 오류): 빈 set 으로 degrade. `codeowners-only` 는 reviewer 미지정. `merge` 는 config 만.
+- **CODEOWNERS 파일 파싱 오류** (잘못된 라인): 해당 라인만 skip + slog.Debug, 나머지 라인 정상 처리.
+- **issue.assignees 부재** (`InheritIssueAssignee=true` 인데 빈 배열): 정상 — 후보에 추가하지 않음.
+- **자기 자신만 남는 케이스** (sanitize 후보가 0명): reviewer 미지정으로 PR 생성 + slog.Debug.
+
+### 6.3 모드 의사결정 매트릭스
+
+| `reviewer_strategy` | `reviewers` | CODEOWNERS | 결과 |
+|---------------------|-------------|------------|------|
+| 미설정 / `config-only` | `[user1]` | 무관 | `[user1]` |
+| `codeowners-only` | 무관 (무시) | 매치된 owner | CODEOWNERS 결과만 |
+| `merge` | `[user1]` | `[user2, @org/team]` | `[user1, user2, org/team]` |
+| `merge` | `[]` | `[user2]` | `[user2]` |
+| `merge` | `[user1]` | (404) | `[user1]` |
+| `codeowners-only` | `[user1]` | (404) | `[]` (warning) |
+
+`InheritIssueAssignee=true` 면 위 결과에 task.IssueAssignees 합집합 추가.
+
+## 7. 데이터 모델 (요약)
+
+기존 `Task` 엔티티에 다음 1개 필드 추가:
+
+```
+Task.IssueAssignees []string  // task 픽업 시점의 issue.assignees 스냅샷 (login 만)
+                              // SQLite 컬럼: TEXT (JSON encoded), default '[]'
+```
+
+신규 EventKind 1개:
+
+```
+const EventKindReviewerWarning EventKind = "reviewer_warning"
+// payload_json: {"rejected": ["user1", "org/team"], "reason": "could not request reviewer"}
+```
+
+신규 AppState 키 없음. CODEOWNERS 캐시는 메모리 only (재시작 시 cold start 허용).
+
+마이그레이션:
+
+```
+migrations/000004_add_task_issue_assignees.up.sql
+  ALTER TABLE tasks ADD COLUMN issue_assignees TEXT NOT NULL DEFAULT '[]';
+migrations/000004_add_task_issue_assignees.down.sql
+  ALTER TABLE tasks DROP COLUMN issue_assignees;
+```
+
+## 8. API 계약 (요약)
+
+신규 HTTP 엔드포인트는 없음. 기존 `GET /tasks/{id}` 응답 DTO 에 `issue_assignees: string[]` + `reviewer_warnings: string[]` (마지막 reviewer_warning 이벤트의 rejected) 추가.
+
+`config.yaml` 스키마 확장:
+
+```yaml
+github:
+  repos:
+    - name: "owner/repo"
+      default_branch: "main"
+      labels: ["claude-ops"]
+
+      # 기존 — config 명시적 선언
+      reviewers: ["user1"]
+
+      # 신규 — reviewer 결정 전략. 미설정 시 "config-only" (= 기존 동작).
+      reviewer_strategy: "merge"   # config-only | codeowners-only | merge
+
+      # 신규 — 이슈 assignee 도 reviewer 후보에 포함 (직교 옵션)
+      inherit_issue_assignee: false
+
+      checks:
+        security: true
+        perf: false
+```
+
+내부 인터페이스 (Go):
+
+```go
+// internal/github/codeowners 패키지
+type Codeowners interface {
+    // OwnersFor returns the union of owners (users + teams) for the given
+    // changed file paths in the given repo. Returns empty slice if CODEOWNERS
+    // does not exist or no rule matches.
+    OwnersFor(ctx context.Context, repo string, changedFiles []string) ([]string, error)
+}
+
+// internal/github 패키지에 신규 추가
+type ReviewerResolver interface {
+    Resolve(ctx context.Context, task *domain.Task, worktreePath string,
+            repoCfg config.RepoConfig) (reviewers []string, warnings []string, err error)
+}
+```
+
+## 9. 비기능 요구사항
+
+| 항목 | 요구 |
+|------|------|
+| 성능 | reviewer 결정 (CODEOWNERS 캐시 히트 기준) p95 < 50ms. 캐시 미스 (GitHub API 1콜) 포함 p95 < 800ms |
+| 회귀 안전 | `reviewer_strategy` 미설정 레포는 v0 동작 유지 (기존 yaml 무수정) |
+| 보안 | CODEOWNERS 응답이 base64 디코드 시 UTF-8 미매치면 raw 보존 + slog.Warn. PII (user email) 가 CODEOWNERS 에 포함될 수 있으니 로그 출력 시 user login 만 노출 |
+| 관측성 | reviewer 결정 결과 (strategy, count, source breakdown) 를 Task 에 `task_event{kind=reviewer_decided}` 로 1건 기록 (payload 에 sources: {config: N, codeowners: N, assignees: N}) |
+| 캐시 | 메모리 LRU 64 entries × TTL 60s. 멀티 인스턴스는 v1 미고려 |
+| 테스트 커버리지 | 패키지별 ≥ 85% (`internal/github/codeowners`, `internal/github/reviewer_resolver`) — Go CLAUDE.md 게이트 + 부모 PRD §9 따름 |
+| lint | `golangci-lint run ./...` 통과 |
+| swag | 신규 HTTP 핸들러 없음 (응답 DTO 확장만) — `GetTask` 핸들러의 `@Success` 응답 모델 godoc 갱신 |
+
+## 10. 의존성 / 리스크
+
+**의존성**
+- `github.com/google/go-github/v60` — `Repositories.GetContents` 또는 `Repositories.DownloadContents` 로 CODEOWNERS fetch (이미 `internal/github/client.go` 에서 사용 중)
+- `git diff --name-only origin/{base}..HEAD` — worktree 에서 실행 가능 (Worker 가 push 직후, PR 생성 직전 단계 보장)
+- 기존 `gh pr create --reviewer` 인터페이스 — 변경 없음
+
+**리스크**
+- **R1 (Med)**: CODEOWNERS 매칭 규칙은 GitHub 공식 동작과 완전히 동일하지 않을 수 있음 (특히 wildcard 우선순위) → v1 은 "마지막 매치 우선" 단순 규칙 + 단위 테스트로 GitHub 문서 예시 case 5종 검증. 미스매치 신고 시 issue 생성하여 추후 보정.
+- **R2 (Low)**: `gh pr create` stderr 의 partial-reject 메시지 포맷이 gh 버전 업데이트로 변경되면 parsing 깨짐 → 정규식 보수적 매칭 + 알 수 없는 형태는 "전체 실패" 로 fallback (안전 측). 통합 테스트에서 gh 2.x major 변경 시 fixture 갱신.
+- **R3 (Low)**: `inherit_issue_assignee=true` + 이슈 assignee 가 다수 (>10) 인 경우 reviewer 한도 (15) 초과 → 우선순위 정해서 cut: config > codeowners > assignees. cut 시 warning.
+- **R4 (Low)**: 캐시 stale → 운영자가 CODEOWNERS 를 막 수정한 직후 60초간 옛 owner 가 reviewer 로 지정될 수 있음. 허용 trade-off (TTL 짧음).
+- **R5 (Low)**: PR author 식별 — `gh api user` 호출 결과를 startup 시 1회 캐시. 토큰 권한 부족하면 빈 string → self-exclude 동작 안 함 (gh 가 거부하므로 partial-reject 경로로 흐름).
+
+## 11. 범위 외 (Out of Scope)
+
+- **CODEOWNERS 우선순위 / 와일드카드** 의 GitHub 동작 100% 재현 (v2 후보 — 정확도 이슈 누적되면 검토)
+- **PR 생성 후 reviewer 추가** (`gh pr edit --add-reviewer`) 보정 경로
+- **GitHub App 기반 인증** — 현재 PAT 만 지원
+- **Reviewer rotation / round-robin** — 단순 합집합만
+- **Slack 에서 reviewer 즉시 변경 버튼** (v2 후보)
+- **GitLab Approver Rule, Bitbucket Default Reviewer** 호환
+
+## 12. 오픈 이슈
+
+- [ ] **OI-1**: `inherit_issue_assignee=true` 시 issue.assignees 가 task 큐 시점에 이미 비어있고 PR 직전에 다시 fetch 해야 하는 케이스 — 폴링 시점과 PR 생성 시점 간격이 큰 경우 (full mode + queued task) assignee 가 추가되었으면? v1 결정: **task 큐 시점 스냅샷 사용** (단순, 결정 가능). PR 생성 직전 refetch 는 v2 후보.
+- [ ] **OI-2**: CODEOWNERS 위치는 `.github/CODEOWNERS` / `CODEOWNERS` / `docs/CODEOWNERS` 셋 중 하나. v1 은 셋 다 시도 (.github 우선) — 첫 매치 캐시. GitHub 가 Enterprise 서버에서 추가 위치를 지원하는 경우는 무시.
+- [ ] **OI-3**: `reviewer_strategy` 의 default 를 `config-only` 로 둘지 `merge` 로 둘지 — v1 은 회귀 안전 우선 `config-only`. 운영자가 명시적으로 `merge` 옵트인. 추후 6개월 사용 데이터 보고 default 변경 검토.
+
+---
+
+## 참고 — 관련 기존 코드
+
+- `internal/github/pr_creator.go` — `--reviewer` 플래그 생성 위치 (line 93~95)
+- `internal/github/poller.go` — issue.assignees 캡처 추가 지점 (`detectTaskType` 인근)
+- `internal/config/config.go` `RepoConfig` — 신규 필드 추가
+- `internal/config/validate.go` `validateRepos` — `reviewer_strategy` enum 검증 추가
+- `internal/scheduler/worker.go` `createPR` — 호출 시 worktree path 전달 보장 (이미 가능)
+- `internal/slack/blocks.go` — `BuildReviewerWarning` 신규 빌더 추가
+
+단일 스택 프로젝트이므로 역할별 분할 없이 **단일 구현 프롬프트** (`./pr-reviewer-assign/go.md`) 로 전달합니다.

--- a/docs/specs/pr-reviewer-assign/go.md
+++ b/docs/specs/pr-reviewer-assign/go.md
@@ -1,0 +1,389 @@
+# pr-reviewer-assign — Go 구현 가이드
+
+상위 PRD: [`../pr-reviewer-assign.md`](../pr-reviewer-assign.md)
+
+> 이 문서는 PRD 의 결정·근거를 반복하지 않습니다. 단계·체크리스트·수락 기준만 담습니다. 모순 시 PRD 가 우선.
+
+---
+
+## 0. 사전 확인
+
+### CLAUDE.md 핵심 규칙
+- DI 생성자 주입 / 전역 db 금지
+- 모든 레이어 `ctx context.Context` 첫 인자
+- `domain/` 외부 패키지 import 금지 — 본 기능의 `Codeowners`, `ReviewerResolver` 인터페이스는 `internal/github/` 패키지에 두고 domain 은 변경 최소
+- 동적·페이징 쿼리는 sqlc — 본 기능은 SELECT 변경 없음 (issue_assignees 컬럼 추가만)
+- 모든 신규/변경 핸들러 swag godoc 필수
+- 기존 migration 수정 금지 — `000004_add_task_issue_assignees.{up,down}.sql` 신규만
+- 테스트 없이 UseCase 메서드 추가 금지
+- 커버리지 ≥80%, `internal/github/codeowners`, `internal/github/reviewer_resolver` 패키지는 ≥85%
+
+### 영향받는 기존 파일 (수정)
+- `internal/domain/task.go` — `IssueAssignees []string` 필드 추가, `EventKindReviewerWarning` (그리고 `EventKindReviewerDecided`) 상수
+- `internal/repository/task_repository.go` — `gormTask` 의 `issue_assignees` 컬럼 매핑 (TEXT JSON 인코딩)
+- `internal/github/pr_creator.go` — `--reviewer` 플래그 생성 위치 (line 93~95) 를 `ReviewerResolver.Resolve(...)` 결과로 대체. partial-reject stderr 파싱 + Task URL 추출 로직 추가
+- `internal/github/poller.go` — `detectTaskType` 인근에서 `issue.Assignees` 추출하여 task 메타에 저장 (`Task.IssueAssignees`)
+- `internal/github/client.go` — `GetCodeowners(ctx, repo string) ([]byte, error)` 추가 (`Repositories.DownloadContents` 또는 `GetContents` + base64 디코드). `GetAuthenticatedUser(ctx) (string, error)` 추가 (gh `api user` 또는 go-github `Users.Get(\"\")`) — startup 시 1회 호출 후 캐시
+- `internal/config/config.go` `RepoConfig` — `ReviewerStrategy string`, `InheritIssueAssignee bool` 필드 추가
+- `internal/config/validate.go` `validateRepos` — `reviewer_strategy ∈ {"", "config-only", "codeowners-only", "merge"}` enum 검증 (빈 값은 `config-only` 동의)
+- `internal/scheduler/worker.go` `createPR` — `ReviewerResolver` 호출 추가, worktree path 전달 보장
+- `internal/api/dto.go` `TaskResponse` — `IssueAssignees []string`, `ReviewerWarnings []string` 필드 추가
+- `internal/slack/blocks.go` — `BuildReviewerWarning(task, rejected)` 신규 빌더
+- `internal/slack/client.go` — `NotifyReviewerWarning(...)` 메서드 추가
+- `cmd/scheduled-dev-agent/main.go` — DI 조립
+- `config.example.yaml` — `reviewer_strategy`, `inherit_issue_assignee` 옵션 예시
+
+### 신규 생성 파일
+- `migrations/000004_add_task_issue_assignees.up.sql`
+- `migrations/000004_add_task_issue_assignees.down.sql`
+- `internal/github/codeowners/parser.go` — CODEOWNERS 텍스트 파서 (라인 단위 → `[]Rule{Pattern, Owners}`)
+- `internal/github/codeowners/matcher.go` — 변경 파일 → owner 합집합 (마지막 매치 우선, GitHub 단순 규칙)
+- `internal/github/codeowners/cache.go` — 메모리 LRU (entries=64, TTL=60s) — `hashicorp/golang-lru/v2/expirable` 또는 단순 `sync.Map + time.Time` 구현
+- `internal/github/codeowners/client.go` — `Codeowners` 인터페이스 구현 (`OwnersFor`) — fetcher (3 위치 순차 시도) + cache + parser + matcher 결합
+- `internal/github/reviewer_resolver.go` — `ReviewerResolver` 인터페이스 + 구현
+- `internal/github/reviewer_sanitize.go` — self 제외 / 중복 제거 / >15 cut
+- `internal/github/gh_reject_parser.go` — `gh pr create` stderr partial-reject 메시지 파싱
+- 테스트:
+  - `internal/github/codeowners/parser_test.go` — GitHub 공식 예제 5종 fixture
+  - `internal/github/codeowners/matcher_test.go` — wildcard / last-match / 디렉토리 / `*` / `**`
+  - `internal/github/codeowners/cache_test.go` — LRU TTL / 동시성
+  - `internal/github/reviewer_resolver_test.go` — PRD §6.3 의사결정 매트릭스 테이블 테스트
+  - `internal/github/reviewer_sanitize_test.go`
+  - `internal/github/gh_reject_parser_test.go` — gh 2.x stderr 샘플 fixture
+  - `internal/github/pr_creator_test.go` — 회귀 + reviewer 통합
+
+> Migration 은 `issue_assignees` 컬럼 1개만 추가. config 만 확장.
+
+---
+
+## 1. 단계별 작업
+
+### Step 1 — Migration
+
+**파일**: `migrations/000004_add_task_issue_assignees.up.sql`
+```sql
+ALTER TABLE tasks ADD COLUMN issue_assignees TEXT NOT NULL DEFAULT '[]';
+```
+
+`000004_*.down.sql`:
+```sql
+ALTER TABLE tasks DROP COLUMN issue_assignees;
+```
+
+**수락 기준**
+- migrate up/down 정상 적용
+- 기존 row 들이 `issue_assignees='[]'` 로 초기화 (US-1 회귀 안전)
+
+**Sub-agent**: `go-generator`
+
+### Step 2 — Domain
+
+**작업 내용**
+1. `internal/domain/task.go`:
+   ```go
+   type Task struct {
+       // ... 기존 ...
+       IssueAssignees []string  // 픽업 시점의 issue.assignees 스냅샷 (login)
+   }
+
+   const (
+       EventKindReviewerWarning EventKind = "reviewer_warning"
+       EventKindReviewerDecided EventKind = "reviewer_decided"
+   )
+   ```
+2. domain repository 인터페이스 변경 없음 (issue_assignees 는 task entity 일부)
+
+**수락 기준**
+- `go vet` 통과
+- domain 외부 import 없음
+
+**Sub-agent**: `go-modifier`
+
+### Step 3 — Repository
+
+**작업 내용**
+- `internal/repository/task_repository.go` `gormTask`:
+  ```go
+  type gormTask struct {
+      // ... 기존 ...
+      IssueAssignees string `gorm:"column:issue_assignees;not null;default:'[]'"`
+  }
+  ```
+- domain ↔ gormTask 매핑 시 JSON marshal/unmarshal (`encoding/json`)
+- nil/빈 슬라이스 → `'[]'` 일관 처리
+
+**수락 기준**
+- 통합 테스트 (sqlite):
+  - `Create(task with IssueAssignees=["u1","u2"])` → SELECT 후 동일 슬라이스
+  - `Create(task with nil)` → SELECT 후 `[]string{}` (nil 아님)
+- 회귀: 기존 task_repository_test 전부 통과
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-modifier` + `go-tester`
+
+### Step 4 — UseCase
+
+**작업 내용**
+- `internal/usecase/task_usecase.go` 의 `EnqueueFromIssue` (또는 동등 함수) 가 `issue.Assignees` 를 `Task.IssueAssignees` 에 저장하도록 시그니처 / 매핑 추가
+- `TaskResponse` 매핑 함수 (DTO 변환) 가 `IssueAssignees`, `ReviewerWarnings` 채우도록 확장
+- `ReviewerWarnings` 는 마지막 `reviewer_warning` 이벤트의 `payload.rejected` 를 추출 — repository 의 task event 조회 로직 재사용 (또는 task fetch 시 join)
+
+**수락 기준**
+- mock TaskRepo + TaskEventRepo 단위 테스트:
+  - 이슈 픽업 시 assignees 스냅샷 저장
+  - GetTask(id) → ReviewerWarnings 가 마지막 reviewer_warning event 의 rejected 와 일치
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-modifier` + `go-tester`
+
+### Step 5 — Codeowners 패키지 (`internal/github/codeowners`)
+
+**작업 내용 (4개 파일)**
+
+#### `parser.go`
+- 입력: `[]byte` CODEOWNERS 본문
+- 라인 단위 처리:
+  - `#` 시작 / 빈 줄 → skip
+  - `<pattern> <owner1> <owner2> ...` 형식 → `Rule{Pattern, Owners}` (owner 는 `@` prefix 제거 후 보존, `@org/team` 은 `org/team` 형식 유지)
+  - 잘못된 라인 → skip + slog.Debug
+- 출력: `[]Rule`
+
+#### `matcher.go`
+- 입력: `[]Rule`, `[]string changedFiles`
+- 알고리즘 (PRD §10 R1 — GitHub "마지막 매치 우선" 단순 규칙):
+  ```
+  for file in changedFiles:
+    matched := nil
+    for rule in rules:    // 순서대로
+      if rule.Pattern matches file: matched = rule  // 최후 매치가 winner
+    if matched != nil: result.AddAll(matched.Owners)
+  return result.Sorted()  // 결정성
+  ```
+- 패턴 매칭: `*`, `**`, 디렉토리 `/path/`, suffix `*.go`, prefix 등 — `path.Match` 또는 `doublestar/v4` 라이브러리
+- 단위 테스트: GitHub 공식 docs 예제 5종 fixture (`docs/CODEOWNERS-examples.md` 참조 — 또는 인라인 fixture)
+
+#### `cache.go`
+- LRU (entries=64) + TTL (60s)
+- 키: `repo full_name`, 값: `[]Rule` + fetched_at
+- 미스 시 fetcher 호출
+- ETag 미지원 (v1 — OI 외)
+
+#### `client.go`
+- `OwnersFor(ctx, repo, changedFiles []string) ([]string, error)`
+  - 캐시 조회 → 미스면 GitHub fetch
+  - GitHub fetch: 3 위치 순차 시도 (`.github/CODEOWNERS` → `CODEOWNERS` → `docs/CODEOWNERS`), 첫 매치만 캐시
+  - 모두 404 → `ErrCodeownersNotFound` (sentinel) 반환 + 빈 slice
+  - 5xx → 1회 재시도 (250ms backoff) → 여전히 실패 시 `ErrCodeownersFetch` + 빈 slice + slog.Warn
+  - parser → matcher → 결과
+
+**수락 기준**
+- parser 5+ 케이스 테스트 (주석/와일드카드/팀/디렉토리/잘못된 라인)
+- matcher 8+ 케이스: `*`, `**`, last-match wins, `*.go`, `/docs/`, prefix `src/api/`, 매치 없음, 다중 파일 union
+- cache 테스트: hit/miss/TTL 만료/`-race` 동시성
+- client 테스트 (mock GitHubClient):
+  - 첫 위치 200 → 캐시 + 결과
+  - 첫 위치 404 → 두 번째 시도 → 200
+  - 모든 위치 404 → ErrCodeownersNotFound + 빈 slice
+  - 5xx → 1 retry → 여전히 실패 시 빈 slice + Warn
+- 커버리지 ≥ 90%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 6 — ReviewerResolver (`internal/github/reviewer_resolver.go`)
+
+**작업 내용**
+- 인터페이스:
+  ```go
+  type ReviewerResolver interface {
+      Resolve(ctx context.Context, task *domain.Task, worktreePath string,
+              repoCfg config.RepoConfig) (reviewers []string, warnings []string, err error)
+  }
+  ```
+- 구현 (PRD §6.1 1:1):
+  1. `changedFiles` 추출: `git -C <worktreePath> diff --name-only origin/<base>..HEAD` (실패 시 빈 slice + warning)
+  2. strategy 분기:
+     - `""` / `"config-only"` → `candidates = repoCfg.Reviewers`
+     - `"codeowners-only"` → `candidates = codeowners.OwnersFor(...)` (404 면 빈 slice)
+     - `"merge"` → `union(repoCfg.Reviewers, codeowners.OwnersFor(...))`
+  3. `repoCfg.InheritIssueAssignee` true → `candidates ∪= task.IssueAssignees`
+  4. `sanitize(candidates)`: self 제외 (`PRAuthor` startup 캐시값) / 대소문자 무시 중복 제거 / cut to 15 (config > codeowners > assignees 우선순위는 sanitize 단계에서 reorder)
+  5. `TaskEvent{kind=reviewer_decided, payload={sources: {config:N, codeowners:N, assignees:N}, final:[...]}}` 1건 기록
+  6. 반환
+
+**수락 기준**
+- 테이블 테스트 — PRD §6.3 의사결정 매트릭스 6 케이스 + `inherit_issue_assignee=true` 직교 6 케이스 = 12+ 케이스
+- self exclude: candidates=["bot","u1"] + PRAuthor="bot" → 결과 ["u1"]
+- > 15 인 경우 우선순위 cut 검증 + warning 발생
+- changedFiles 추출 실패 시 codeowners-only 는 빈 slice + warning, merge 는 config 만
+- `git diff` mock (또는 worktree fixture) 으로 실측 케이스 1+
+- 커버리지 ≥ 90%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 7 — gh stderr partial-reject 파싱 (`internal/github/gh_reject_parser.go`)
+
+**작업 내용**
+- 입력: `gh pr create` stderr 텍스트 + non-zero exit code
+- 정규식 (보수적): `(?m)^.*[Cc]ould not (?:request|add) reviewer (?:'|")?(\S+?)(?:'|")?\s*[:.]?$` 등 gh 2.x 메시지 패턴 — 실측 fixture 기반
+- 출력: `(prURL string, rejected []string, isPartial bool)`
+  - PR URL 이 stdout 또는 stderr 에 포함되어 있으면 `isPartial=true` (PR 자체는 생성됨)
+  - 없으면 `isPartial=false` → 호출자가 "전체 실패" 로 fallback (안전 측 — PRD §10 R2)
+
+**수락 기준**
+- gh 2.x stderr fixture 5+ 케이스:
+  - 단일 reviewer 거부 + PR URL 정상 출력 → isPartial=true, rejected=["user1"]
+  - 다중 거부 + PR URL → rejected 다수
+  - PR URL 없음 + 거부 → isPartial=false (전체 실패)
+  - 미지의 메시지 → isPartial=false (안전 측)
+- 정규식 보수성: 무관한 라인 무시
+- 커버리지 ≥ 90%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 8 — pr_creator.go 수정
+
+**작업 내용**
+- 기존 `--reviewer` flatten 위치 (line 93~95) 를 `ReviewerResolver.Resolve(...)` 결과로 대체
+- `gh pr create` 실행 후 stderr/stdout 캡처:
+  - 성공 (exit 0) → 정상 PR URL 반환
+  - exit non-zero → `gh_reject_parser` 통해 분석:
+    - `isPartial=true` → PR URL + rejected slice 반환, `TaskEvent{kind=reviewer_warning, payload={rejected, reason}}` + Slack `NotifyReviewerWarning` 발송, 함수는 PR URL 반환 (성공 처리)
+    - `isPartial=false` → 기존처럼 에러 반환
+- candidate 가 빈 slice 면 `--reviewer` 플래그 자체 생략 (gh 가 빈 값 거부 안 하도록)
+
+**수락 기준**
+- 회귀 테스트 (기존 `pr_creator_test`):
+  - reviewer_strategy 미설정 + reviewers=["u1"] → ghArgs 가 `--reviewer u1` 단일 (v0 동작과 바이트 동일 — US-1 수락 1)
+  - reviewers=[] → `--reviewer` 미포함
+- 신규 테스트:
+  - merge 모드 + CODEOWNERS hit → 합집합 reviewer
+  - codeowners-only + 404 → reviewer 미지정 + slog.Warn
+  - partial-reject → PR URL 반환 + reviewer_warning 이벤트 1건 + Slack 호출 1회
+  - 전체 실패 → 에러 반환 (기존 동작)
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-modifier` + `go-tester`
+
+### Step 9 — Poller / Worker / API 통합
+
+**작업 내용**
+1. `internal/github/poller.go`:
+   - `detectTaskType` 인근에서 `issue.Assignees` 의 `Login` slice 추출 → `Task.IssueAssignees` 로 enqueue
+2. `internal/scheduler/worker.go` `createPR`:
+   - `ReviewerResolver` 호출, worktree path 전달 (이미 가능 — 기존 함수 시그니처 활용)
+3. `internal/api/dto.go` `TaskResponse`:
+   - `IssueAssignees []string \`json:"issue_assignees" example:"[\"user1\"]"\``
+   - `ReviewerWarnings []string \`json:"reviewer_warnings,omitempty" example:"[\"user2\"]"\``
+4. `GetTask` handler godoc `@Success` 모델 업데이트 (DTO 변경만 — 신규 핸들러는 없음)
+
+**수락 기준**
+- poller_test: assignees 가 task.IssueAssignees 에 저장됨
+- API e2e (httptest): `GET /tasks/{id}` 응답에 신규 2개 필드 포함, swag 재생성 후 노출
+- 커버리지 ≥ 80%
+
+**Sub-agent**: `go-modifier` + `go-tester`
+
+### Step 10 — DI 조립 (`cmd/scheduled-dev-agent/main.go`)
+
+**작업 내용**
+- startup 시 `prAuthor, err := ghClient.GetAuthenticatedUser(ctx)` 호출 (실패 시 `prAuthor=""` + Warn — sanitize self-exclude 동작 안 함, gh 가 거부 처리)
+- `coCache := codeowners.NewCache(64, 60*time.Second)`
+- `coClient := codeowners.NewClient(ghClient, coCache)`
+- `resolver := github.NewReviewerResolver(coClient, prAuthor, slog)`
+- `prCreator := github.NewPRCreator(ghClient, resolver, slackClient)` (기존 시그니처 확장)
+- worker 에 `prCreator` 주입
+
+**수락 기준**
+- `go build ./...` 통과
+- `gh api user` 실패 케이스도 부팅 정상 (Warn 후 진행)
+
+**Sub-agent**: `go-modifier`
+
+### Step 11 — 검증
+
+```bash
+sqlc generate                            # 본 기능은 sqlc 변경 없음, 기존 그대로 통과
+mockery --name=Codeowners        --dir=internal/github/codeowners --output=mocks
+mockery --name=ReviewerResolver  --dir=internal/github            --output=mocks
+mockery --name=GitHubClient      --dir=internal/github            --output=mocks
+go build ./...
+go test -race -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out | tail -1                                    # ≥80%
+go tool cover -func=coverage.out | grep -E '(codeowners|reviewer_resolver)'   # ≥85%
+go vet ./...
+golangci-lint run ./...
+swag init -g cmd/scheduled-dev-agent/main.go -o docs
+```
+
+**수락 기준 (전체)**
+- 모든 명령 0 exit
+- `.claude/hooks/pre-push.sh` 통과
+- swag 재생성 후 `TaskResponse` 에 `issue_assignees`, `reviewer_warnings` 노출
+- 회귀 0건: 기존 yaml (reviewer_strategy 미설정) → 기존 ghArgs 와 바이트 단위 동일 (US-1 핵심)
+
+---
+
+## 2. PRD 수락 기준 매핑
+
+| PRD Goal | 검증 |
+|----------|------|
+| G1. 기존 동작 100% (회귀 0) | pr_creator_test US-1 케이스 — ghArgs byte-identical |
+| G2. CODEOWNERS 자동 (merge / only) | resolver_test 의 §6.3 매트릭스 |
+| G3. inherit_issue_assignee 직교 적용 | resolver_test 의 12 직교 케이스 |
+| G4. reviewer 실패 → PR 자체는 성공 | gh_reject_parser_test + pr_creator_test partial 케이스 |
+| G5. self / 빈 후보 자동 제외 | reviewer_sanitize_test |
+| G6. team `@org/team` 동일 처리 | parser_test + resolver_test 의 team 케이스 |
+| G7. CODEOWNERS API ≤ 1회/PR (TTL 60s) | cache_test hit/miss 검증 |
+
+| PRD User Story | 검증 |
+|----------------|------|
+| US-1 (기존 동작 유지) | pr_creator_test 회귀 |
+| US-2 (codeowners-only) | resolver_test |
+| US-3 (merge) | resolver_test + 15 cap |
+| US-4 (assignee 상속) | poller_test + resolver_test 직교 |
+| US-5 (sanitize / partial-reject) | sanitize_test + gh_reject_parser_test |
+| US-6 (team) | parser_test |
+| US-7 (CODEOWNERS 부재) | client_test 404 케이스 |
+| US-8 (캐시) | cache_test |
+
+---
+
+## 3. CLAUDE.md NEVER 체크리스트
+
+- [ ] `domain/` 외부 패키지 import 금지 — `IssueAssignees []string` 만 추가
+- [ ] raw SQL 금지 — issue_assignees 는 GORM 컬럼만 변경, 추가 SQL 없음
+- [ ] 전역 var db 금지 — 모든 의존 cmd/main.go 주입
+- [ ] `context.Background()` 핸들러 직접 사용 금지
+- [ ] swag godoc 없는 endpoint 추가 금지 — 본 기능은 신규 endpoint 없음, `GetTask` `@Success` 모델만 갱신
+- [ ] 기존 migration 파일 수정 금지 — 000004 신규만
+- [ ] 테스트 없이 UseCase 메서드 추가 금지 — 모든 신규 메서드 단위 테스트 동시 추가
+- [ ] secret/PII 로그 금지 — CODEOWNERS 응답에 user email 포함될 수 있음 → 로그 출력은 user login 만 (PRD §9 보안)
+- [ ] `panic()` 금지 — 모든 에러 반환 + degrade
+- [ ] `db/sqlc/` 수동 수정 금지
+
+---
+
+## 4. OI / 후속 결정 (PRD §12 와 동기화)
+
+- **OI-1** (assignee 스냅샷 vs PR 직전 refetch): v1 은 **task 큐 시점 스냅샷** 사용 — poller 에서 캡처. PR 직전 refetch 는 v2 후보
+- **OI-2** (CODEOWNERS 위치): `.github/CODEOWNERS` → `CODEOWNERS` → `docs/CODEOWNERS` 순. 첫 매치만 캐시
+- **OI-3** (default `reviewer_strategy`): v1 은 `config-only` (회귀 안전 우선). config.example.yaml 에는 `merge` 예시를 주석으로 노출하여 옵트인 유도
+
+---
+
+## 5. 후속 수동 작업
+
+```bash
+# config.example.yaml 에 신규 옵션 예시 추가 (PRD §8 yaml 그대로)
+github:
+  repos:
+    - name: "owner/repo"
+      reviewers: ["user1"]
+      reviewer_strategy: "merge"        # config-only | codeowners-only | merge
+      inherit_issue_assignee: false
+
+# README "Reviewer Assignment" 섹션 추가:
+# - 모드 3종 차이
+# - CODEOWNERS 캐시 TTL 60s 설명
+# - GITHUB_TOKEN 의 contents 읽기 권한 필요 명시 (PRD §4 권한)
+```

--- a/docs/specs/usage-dashboard.md
+++ b/docs/specs/usage-dashboard.md
@@ -1,0 +1,261 @@
+# PRD — usage-dashboard
+
+| 항목 | 값 |
+|------|-----|
+| 작성일 | 2026-04-27 |
+| 상태 | draft |
+| 스택 범위 | Go (단일 바이너리 — scheduled-dev-agent 확장) |
+| 우선순위 | P1 |
+| 작성자 | gs97ahn@gmail.com |
+| 관련 PRD | [`./scheduled-dev-agent.md`](./scheduled-dev-agent.md) §7 데이터 모델, §10 R6, §12 OI-1 |
+
+---
+
+## 1. 배경 (Background)
+
+`scheduled-dev-agent` 는 이미 Claude CLI 의 `stream-json` 출력에서 `result.total_cost_usd`, `result.usage.{input,output,cache_*}`, `result.modelUsage[model].{inputTokens,outputTokens,costUSD,...}` 까지 NDJSON 으로 파싱하고 있다 (§12 OI-1, `internal/claude/stream/events.go`). 하지만 worker 는 이 중 `EstimatedInputTokens` / `EstimatedOutputTokens` 두 컬럼만 Task 에 저장하고 비용 (`total_cost_usd`) 과 모델 단위 분해 (`modelUsage`) 는 휘발 중이다.
+
+운영자는 "이번 주 plan 으로 얼마를 썼는지", "어떤 모델이 cost 의 대부분을 차지하는지", "남은 한도 대비 얼마나 위험한지" 를 알 수 없다. 현재 한도 게이트는 task **개수** 캡 (US-11) 과 CLI rate-limit 신호 (US-12) 만으로 동작하므로, 비용·토큰 단위의 사전 throttling 이 불가능하다.
+
+이 기능은 (1) Task 테이블에 cost·model 분해를 영속화하고, (2) 일/주/월 집계 API 를 제공하며, (3) 비용 한도 임계치에 도달하면 Slack warn 을 발송한다. v1 은 **조회 + 경고** 까지이며 한도 도달 시 dispatch 차단은 후속 이터레이션에서 검토.
+
+## 2. 목표 (Goals)
+
+- G1. Claude CLI `result` 이벤트의 `total_cost_usd` 와 `modelUsage` 가 **task 종료 시점 100%** Task 행에 영속화 (성공·실패·취소 무관, 결과 이벤트 수신된 모든 task)
+- G2. `GET /usage?from=&to=&group_by=day|week|month` 가 토큰·비용·task 수 집계를 반환 (p95 < 200ms, task 수 ≤ 10k 기준)
+- G3. 모델 단위 분해 조회 지원 — `GET /usage/by-model` 또는 `group_by` 와 직교하는 `breakdown=model` 옵션
+- G4. 일일/주간 cost 한도 (`limits.daily_max_cost_usd`, `limits.weekly_max_cost_usd`) 에 도달 시 Slack `:warning:` 메시지 1회 발송 (중복 발송 방지 — 동일 버킷에서 한 번만)
+- G5. 기존 task 카운트 캡·rate-limit block 게이트 동작에 영향 없음 (회귀 0건)
+
+## 3. 비목표 (Non-goals)
+
+- 비용 한도 도달 시 dispatch **차단** (v1 은 경고만, v2 검토)
+- 웹 UI 대시보드 (HTTP JSON 응답만)
+- Slack 일일/주간 비용 요약 cron (`/usage` 호출로 갈음, v2 후보)
+- Anthropic API 키 기반 호출 비용 (대상 외 — CLI 세션 비용만)
+- 기존 task 의 retroactive backfill — migration 후 신규 task 부터 적용
+- task 단위 개별 cost 수정 / 조정 API
+- 다중 사용자 / per-user 분해 (단일 사용자 전제)
+
+## 4. 대상 사용자 (Users)
+
+| 페르소나 | 역할 | 목표 |
+|----------|------|------|
+| Solo developer (P1) | scheduled-dev-agent 운영자 | 이번 주 cost / 토큰 사용 추세 파악, plan 한도 도달 전 throttle 결정 |
+| Small team lead (P2) | 1~3인 팀 리드 | 어떤 모델 (Sonnet vs Opus 등) 이 비용의 대부분을 차지하는지 파악해 프롬프트 튜닝 |
+
+권한 모델: 기존과 동일 — 로컬 bind (`127.0.0.1:8787`) HTTP API. 인증 없음 (v1).
+
+## 5. 유저 스토리 (User Stories)
+
+| # | 스토리 | 수락 기준 |
+|---|--------|-----------|
+| US-1 | 운영자로서 task 가 끝나면 그 task 의 **총 비용·토큰·모델별 분해** 가 DB 에 남아있어야 한다 | 1) Task 테이블에 `cost_usd REAL`, `model_usage_json TEXT`, `total_input_tokens`, `total_output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` 컬럼이 추가됨 <br> 2) Worker 가 `result` 이벤트 수신 후 Task.Update 시 위 6개 필드를 채움 (없으면 0 / `{}`) <br> 3) `result` 이벤트 미수신 (crash 등) 시에는 0 / `{}` 유지하고 task 는 failed 처리 (기존 동작) |
+| US-2 | 운영자로서 `GET /usage?from=&to=&group_by=day` 호출로 **일별 사용량 합계** 를 받고 싶다 | 1) `from`, `to` 는 ISO date (`YYYY-MM-DD`), 누락 시 기본값 `to=today`, `from=to-30d` <br> 2) `group_by` ∈ {`day`, `week`, `month`} — 누락 시 `day` <br> 3) 응답: `buckets[]` 각 항목에 `bucket`(예 `2026-04-27`), `task_count`, `cost_usd`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` <br> 4) status=done 인 task 만 집계 (failed/cancelled 는 제외, 단 cost 가 발생했으면 `usage.failed_cost_usd` 별도 필드로 합계 노출) <br> 5) 빈 버킷도 0 으로 채워 응답 (gap-fill — `2026-W17` 같은 키는 빠뜨리지 않음) |
+| US-3 | 운영자로서 **어떤 모델에 얼마나 썼는지** 보고 싶다 | 1) `GET /usage/by-model?from=&to=` → `models[]` 각 항목에 `model_id`, `cost_usd`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `task_count` <br> 2) 또는 `GET /usage?breakdown=model` 도 동일 결과 반환 (선택 — 둘 중 한 형태로 구현) <br> 3) `cost_usd` 내림차순 정렬 <br> 4) `model_id` 가 비어있는 항목 (CLI 출력 누락) 은 `"unknown"` 으로 합산 |
+| US-4 | 운영자로서 **현재 누적 cost** 와 **설정한 일/주 cost 한도 대비 사용률** 을 한 번에 보고 싶다 | 1) `GET /usage/limits` → `daily.{count_usd, max_usd, percent, date}`, `weekly.{count_usd, max_usd, percent, week}` <br> 2) `max_usd` 는 `config.yaml` 의 `limits.daily_max_cost_usd` / `weekly_max_cost_usd`. 미설정 (0) 이면 `max_usd: 0`, `percent: null` <br> 3) `percent` 는 `count_usd / max_usd * 100` (소수점 1자리), `>= 100` 이면 cap 표시 <br> 4) 카운터 리셋 키는 기존 task counter 와 동일 (`reset_tz` 자정, `week_starts_on` 0시) |
+| US-5 | 운영자로서 cost 한도 직전에 **Slack 경고** 를 받고 싶다 | 1) 매 task 종료 시 (Worker 내) 누적 daily/weekly cost 와 한도 비교 <br> 2) `daily.percent` 가 `[80, 100)` 구간 진입 시 `:warning: Daily cost {X}% used (${cur}/${max})` Slack 발송, 동일 일자에서 1회만 <br> 3) `daily.percent >= 100` 시 `:rotating_light: Daily cost cap reached` 발송, 동일 일자에서 1회만 <br> 4) weekly 도 동일 (80%, 100% 두 단계) <br> 5) 발송 여부는 AppState `cost_warn_state` 에 영속 (재시작 후 재발송 안 함) <br> 6) 한도가 0 (미설정) 이면 경고 발송 안 함 |
+| US-6 | 운영자로서 Swagger UI 에서 **새 엔드포인트** 를 즉시 호출해보고 싶다 | 1) `/usage`, `/usage/by-model`, `/usage/limits` 모두 swag godoc (`@Summary`, `@Tags`, `@Param`, `@Success`, `@Failure`, `@Router`) 작성 <br> 2) `swag init -g cmd/scheduled-dev-agent/main.go -o docs` 재생성 후 `/swagger/index.html` 에서 노출 <br> 3) 응답 DTO 의 모든 필드에 `example:"..."` 태그 |
+
+## 6. 핵심 플로우 (Key Flows)
+
+### 6.1 행복 경로 — task 종료 → 영속화 → 집계 조회
+
+```
+1. Worker.RunTask 가 Claude Runner 호출
+2. Runner 가 result 이벤트의 TotalCostUSD, ModelUsage, Usage 를 RunResult 에 채워 반환
+3. Worker.applyRunUsage 가 task 에 cost_usd / model_usage_json / 4개 토큰 컬럼 적용
+4. TaskRepo.Update 로 영속화 (markDone 직전)
+5. Worker.checkCostThreshold 가 BudgetUseCase.SnapshotCost 호출 → 80% / 100% 진입 시 Slack warn
+6. 운영자가 GET /usage?group_by=week 호출
+7. UsageUseCase 가 sqlc 의 SumUsageByBucket(from, to, bucket_kind) 실행
+8. 결과를 UsageResponse DTO 로 매핑하여 반환
+```
+
+### 6.2 예외 경로
+
+- **`result` 이벤트 미수신 (crash, kill, timeout)**: cost_usd=0, model_usage_json='{}' 로 task 저장. `/usage` 집계에서는 자동으로 0 기여.
+- **`modelUsage` 누락 또는 비어있음**: `model_usage_json='{}'` 로 저장. `GET /usage/by-model` 에서 해당 task 는 합계에 영향 없음.
+- **`from > to` 또는 잘못된 `group_by`**: 400 + `{error: "invalid group_by"}`.
+- **`from`/`to` 가 너무 넓음** (>1년): 기본 limit 적용 후 `warning` 헤더로 안내. 또는 365일 초과 시 400.
+- **Slack 경고 발송 실패**: `slog.Warn` 로깅만, task 종료 자체는 막지 않음. 중복 발송 방지 플래그는 발송 시도 후 set (실패해도 set — 재시도 폭증 방지).
+- **한도 미설정** (`daily_max_cost_usd=0`): warn 비활성화, `/usage/limits` 의 `max_usd=0`, `percent=null`.
+- **시계열 갭**: 빈 버킷도 0 으로 채움 (frontend gap-fill 부담 제거).
+
+## 7. 데이터 모델 (요약)
+
+기존 §7 (scheduled-dev-agent PRD) Task 스키마에 6개 컬럼 추가. 새 마이그레이션 파일로만 추가 (기존 migration 수정 금지 — CLAUDE.md NEVER).
+
+```
+Task (..., 기존 컬럼 ...,
+      cost_usd REAL NOT NULL DEFAULT 0,                        -- result.total_cost_usd
+      total_input_tokens INTEGER NOT NULL DEFAULT 0,           -- result.usage.input_tokens
+      total_output_tokens INTEGER NOT NULL DEFAULT 0,          -- result.usage.output_tokens
+      cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,  -- result.usage.cache_creation_input_tokens
+      cache_read_input_tokens INTEGER NOT NULL DEFAULT 0,      -- result.usage.cache_read_input_tokens
+      model_usage_json TEXT NOT NULL DEFAULT '{}'              -- result.modelUsage 원본 JSON
+      )
+```
+
+기존 `estimated_input_tokens` / `estimated_output_tokens` 는 **유지** (호환성). 신규 컬럼은 result 이벤트 기반의 **권위있는** 값. 두 컬럼 셋 모두 채우되, 집계는 신규 컬럼 사용.
+
+`AppState` 에 키 추가:
+
+```
+key="cost_warn_state",  value={daily_key:"2026-04-27", daily_warned_80:true, daily_warned_100:false,
+                                weekly_key:"2026-W17", weekly_warned_80:false, weekly_warned_100:false}
+```
+
+인덱스: `tasks(created_at)` 는 이미 존재. 집계 쿼리는 `created_at` 또는 `finished_at` 범위 + `status='done'` 필터. 추가 인덱스 불필요 (10k 기준 OK), 필요 시 `idx_tasks_status_finished_at` 추가 검토 (오픈 이슈로).
+
+## 8. API 계약 (요약)
+
+기존 Gin 서버에 라우트 3개 추가. 모두 로컬 bind, 인증 없음 (v1).
+
+```
+GET /usage?from=&to=&group_by=day|week|month     # 시계열 집계
+GET /usage/by-model?from=&to=                    # 모델 단위 합계
+GET /usage/limits                                # 현재 누적 vs 한도
+```
+
+**`GET /usage` 응답 (예시)**:
+
+```json
+{
+  "from": "2026-03-28",
+  "to": "2026-04-27",
+  "group_by": "day",
+  "buckets": [
+    {
+      "bucket": "2026-04-27",
+      "task_count": 4,
+      "cost_usd": 1.23,
+      "input_tokens": 12345,
+      "output_tokens": 6789,
+      "cache_read_tokens": 100,
+      "cache_creation_tokens": 50,
+      "failed_cost_usd": 0.0
+    }
+  ],
+  "totals": {
+    "task_count": 80,
+    "cost_usd": 24.50,
+    "input_tokens": 200000,
+    "output_tokens": 80000,
+    "cache_read_tokens": 5000,
+    "cache_creation_tokens": 2000,
+    "failed_cost_usd": 0.40
+  }
+}
+```
+
+**`GET /usage/by-model` 응답 (예시)**:
+
+```json
+{
+  "from": "2026-03-28",
+  "to": "2026-04-27",
+  "models": [
+    {
+      "model_id": "claude-sonnet-4-5",
+      "task_count": 60,
+      "cost_usd": 18.20,
+      "input_tokens": 150000,
+      "output_tokens": 60000,
+      "cache_read_tokens": 4000,
+      "cache_creation_tokens": 1500
+    },
+    { "model_id": "claude-opus-4-5", "task_count": 20, "cost_usd": 6.30, "...": "..." }
+  ]
+}
+```
+
+**`GET /usage/limits` 응답 (예시)**:
+
+```json
+{
+  "daily":  { "count_usd": 0.85, "max_usd": 1.00, "percent": 85.0, "date": "2026-04-27" },
+  "weekly": { "count_usd": 4.20, "max_usd": 5.00, "percent": 84.0, "week": "2026-W17" }
+}
+```
+
+## 9. 비기능 요구사항 (Non-functional)
+
+| 항목 | 요구 |
+|------|------|
+| 성능 | `/usage` p95 < 200ms (task 수 ≤ 10k). sqlc 생성 쿼리 사용, raw SQL 금지 |
+| 정확도 | 집계 결과는 동일 기간 task 행 합계와 ±0.001 USD 일치 |
+| 일관성 | task 종료 → DB 반영까지 동일 트랜잭션 (Update + 카운터 += 1 은 분리되어도 OK, 양쪽 모두 멱등) |
+| 보안 | 비용·토큰 수치는 PII 아님 — 평문 저장 OK. 로컬 bind 기본 |
+| 테스트 커버리지 | 80% 이상 (CLAUDE.md 게이트). usage 집계 패키지 (sqlc 매핑·gap-fill·warn 게이트) **85% 이상** |
+| lint | `golangci-lint run ./...` 통과 |
+| 문서 | swag godoc + `/swagger/index.html` 갱신 |
+| 호환성 | 기존 `/tasks`, `/modes/*` 응답 스키마 변경 없음 (필드 추가만 가능) |
+| Migration | 단방향 추가 + down 에서 컬럼 drop. 기존 `000001_create_tasks_table.up.sql` 수정 금지 |
+
+## 10. 의존성 / 리스크
+
+**의존성**
+- 기존 `internal/claude/stream` 의 `ResultEvent.TotalCostUSD`, `ModelUsage` 파싱 (이미 구현됨)
+- `internal/usecase/budget_usecase.go` 의 `BudgetCounters` 키 산출 로직 (`DailyKey`, `WeeklyKey`) — cost 카운터 키 산출에 재사용
+- `internal/scheduler/budget_gate.go` 의 `RolloverCounters` — cost 버킷에도 동일 의미로 적용
+- `internal/slack/client.go` — warn 메시지 발송용 새 메서드 (`NotifyCostWarning`) 추가
+- sqlc CLI (이미 설치됨, `sqlc.yaml` 존재)
+
+**리스크**
+- **R1 (Med)**: `result` 이벤트의 `total_cost_usd` 가 CLI 버전 업그레이드로 누락되거나 단위가 바뀌면 0 누적 → §10 R1 의 stream 파서 fallback 정책으로 흡수. 0 USD 인 task 는 모니터링 로그로 감지 (slog.Info "task done with zero cost").
+- **R2 (Med)**: `model_usage_json` 을 TEXT 로 저장하면 by-model 집계 시 N+1 또는 application-side scan 이 됨 → 10k 기준은 문제 없으나, 향후 100k 단위 되면 별도 `task_model_usages` 테이블 정규화 필요. v1 는 application-side group-by 로 충분 (오픈 이슈).
+- **R3 (Low)**: cost 한도 임계 80% 진입 후 task 가 한 번에 90% → 100% 로 점프하면 80% warn 은 발송하되 100% warn 도 별도 발송 — 두 단계가 독립이라 OK. 단, `[80,100)` 진입 검사가 "이전 percent < 80 && 현재 >= 80" 가 아니라 단순 `>= 80` 이면 매 task 마다 발송될 수 있음 → AppState `daily_warned_80` 플래그로 멱등화 필수.
+- **R4 (Low)**: 빈 버킷 gap-fill 시 timezone 처리 — `reset_tz` 기준으로 일/주/월 키 산출. UTC 기준이면 한국 시간 자정 경계에서 어긋남 → 기존 `BudgetCounters` 의 키 산출 로직과 동일하게 `reset_tz` 적용.
+- **R5 (Low)**: failed_cost_usd 가 done 합계와 별도라는 것을 운영자가 모르면 합계 불일치로 오해 → 응답 DTO 의 `failed_cost_usd` 필드와 swag description 으로 명시.
+
+## 11. 범위 외 (Out of Scope)
+
+- cost 한도 도달 시 dispatch 자동 차단 (v2 검토 — task count cap 처럼 budget gate 에 cost 차원 추가)
+- per-repo / per-issue cost 분해 (필드는 이미 task.repo_full_name 으로 가능, API 만 미제공)
+- 일일 cost 요약 Slack cron (v2)
+- cost 예측 / 추세 그래프
+- cost export (CSV / JSON dump) — `/usage` JSON 응답으로 갈음 가능
+- 기존 task 의 retroactive cost backfill
+- Anthropic API 키 호출 비용 (구독 세션만 대상)
+
+## 12. 오픈 이슈 (Open Questions)
+
+- [ ] **OI-1**: 집계 기준 시각으로 `created_at` 을 쓸지 `finished_at` 을 쓸지. 운영자 직관은 "끝난 시각" 이지만 finished_at 이 NULL 인 running/queued 도 있어 일관성 떨어짐. v1 초안: **`COALESCE(finished_at, created_at)`** 로 산출. 결정 필요.
+- [ ] **OI-2**: `model_usage_json` 정규화 시점 — v1 은 TEXT 로 두고 application-side scan, 10k 임계 도달 시 `task_model_usages(task_id, model_id, ...)` 테이블 도입. 임계치 결정 필요 (50k? 100k?).
+- [ ] **OI-3**: `/usage/by-model` 의 별도 엔드포인트 vs `/usage?breakdown=model` — 응답 스키마가 다르므로 v1 은 **별도 엔드포인트** 권장. 클라이언트 사용성 검증 필요.
+- [ ] **OI-4**: cost warn 임계 (80%) 를 `config.yaml` 로 노출할지 고정할지. v1 초안: **고정 80% / 100%**. 운영자 피드백 후 외부화.
+- [ ] **OI-5**: weekly 키 형식 — ISO week (`2026-W17`) vs `WEEK_OF_YEAR` 정수. 기존 BudgetCounters 가 ISO week 사용 → **ISO week 통일**.
+- [ ] **OI-6**: 한도 도달 후 dispatch 차단 (BudgetGate 에 cost reason 추가) 을 v2 로 미루는 게 맞는지. CLI rate-limit block 이 사실상 wall hit 시 차단하므로 cost 차단은 중복 보험 — 우선순위 낮춤.
+
+---
+
+## 참고 — 영향 받는 파일 (Go 단일 스택)
+
+PRD 단계에서는 개략만. 상세 task 분할은 `./usage-dashboard/go.md` 참조.
+
+```
+migrations/
+  000004_add_cost_columns_to_tasks.{up,down}.sql      # 신규
+db/query/
+  usage.sql                                            # 신규 — sqlc 집계 쿼리
+internal/
+  domain/task.go                                       # Task 구조체에 6개 필드 추가
+  domain/repository.go                                 # UsageRepository 인터페이스 신규
+  repository/task_repository.go                        # gormTask 매핑 6개 필드 추가
+  repository/usage_repository.go                       # 신규 — sqlc-backed 구현체
+  usecase/usage_usecase.go                             # 신규 — gap-fill, by-model, limits
+  usecase/budget_usecase.go                            # 변경 — cost warn state 영속
+  scheduler/worker.go                                  # 변경 — applyRunUsage 확장 + cost warn 트리거
+  claude/runner.go                                     # 변경 — RunResult 에 ModelUsage 포함
+  claude/stream/parser.go                              # 변경 (소량) — Signal.Result 통과
+  api/dto.go                                           # UsageResponse, UsageBucket, ModelUsage* 추가
+  api/usage_handler.go                                 # 신규 — 3개 엔드포인트
+  api/server.go                                        # 변경 — 라우트 등록
+  config/config.go                                     # 변경 — limits.daily_max_cost_usd / weekly_max_cost_usd
+  slack/client.go                                      # 변경 — NotifyCostWarning
+docs/
+  swagger/                                             # swag init 재생성 산출물
+```
+
+단일 스택이므로 역할별 분할 없이 **단일 구현 프롬프트** (`./usage-dashboard/go.md`) 로 전달합니다.

--- a/docs/specs/usage-dashboard/go.md
+++ b/docs/specs/usage-dashboard/go.md
@@ -1,0 +1,410 @@
+# usage-dashboard — Go 구현 가이드
+
+상위 PRD: [`../usage-dashboard.md`](../usage-dashboard.md)
+
+> 이 문서는 PRD 의 결정·근거를 반복하지 않습니다. 단계·체크리스트·수락 기준만 담습니다. 모순 시 PRD 가 우선.
+
+---
+
+## 0. 사전 확인
+
+### CLAUDE.md 핵심 규칙
+- DI 생성자 주입 / 전역 db 금지
+- 모든 레이어 `ctx context.Context` 첫 인자
+- `domain/` 외부 패키지 import 금지
+- 동적·집계·페이징·조인 쿼리는 sqlc 필수 — 본 기능의 `SumUsageByBucket`, `SumUsageByModel`, `SumUsageDaily/Weekly` 모두 sqlc
+- 모든 신규 핸들러 swag godoc 필수, Response DTO 의 모든 필드 `example:"..."` 태그
+- 기존 migration 수정 금지 — `000004_*` 신규 추가만
+- 테스트 없이 UseCase 메서드 추가 금지
+- 커버리지 ≥80% (`internal/usecase/usage_*` 와 sqlc 매핑·gap-fill·warn 게이트는 ≥85%)
+
+### 영향받는 기존 파일 (수정)
+- `internal/domain/task.go` — Task 구조체에 6개 필드 추가 (`CostUSD float64`, `TotalInputTokens int64`, `TotalOutputTokens int64`, `CacheCreationInputTokens int64`, `CacheReadInputTokens int64`, `ModelUsageJSON string`)
+- `internal/domain/repository.go` — 기존 `TaskRepository` 변경 없음. 신규 `UsageRepository` 인터페이스 추가
+- `internal/repository/task_repository.go` — `gormTask` 매핑 6개 필드 추가
+- `internal/usecase/budget_usecase.go` — `cost_warn_state` AppState 영속 + 80%/100% 임계 평가 메서드 (`EvaluateCostWarn`)
+- `internal/scheduler/worker.go` — `applyRunUsage` (또는 동등 함수) 확장 → `RunResult` 의 cost / modelUsage / 4개 토큰 컬럼을 Task 에 적용 + cost warn 트리거
+- `internal/claude/runner.go` — `RunResult` 에 `ModelUsage` 필드 추가 (이미 `total_cost_usd` / `Usage` 는 파싱 중이지만 worker 까지 전달되는지 확인)
+- `internal/claude/stream/parser.go` — `Signal.Result.ModelUsage` 가 worker 까지 통과되도록 매핑 추가 (소량 변경)
+- `internal/api/dto.go` — `UsageResponse`, `UsageBucket`, `UsageTotals`, `ModelUsageResponse`, `ModelUsageItem`, `UsageLimitsResponse` DTO 추가
+- `internal/api/server.go` — 3개 라우트 등록
+- `internal/config/config.go` — `Limits.DailyMaxCostUSD float64`, `Limits.WeeklyMaxCostUSD float64` 추가
+- `internal/config/validate.go` — 음수 금지, 0 허용 (미설정 의미)
+- `internal/slack/client.go` — `NotifyCostWarning(ctx, scope, percent, current, max)` 추가
+- `cmd/scheduled-dev-agent/main.go` — DI 조립
+- `config.example.yaml` — `limits.daily_max_cost_usd`, `weekly_max_cost_usd` 추가
+
+### 신규 생성 파일
+- `migrations/000004_add_cost_columns_to_tasks.up.sql`
+- `migrations/000004_add_cost_columns_to_tasks.down.sql`
+- `db/query/usage.sql` — sqlc 집계 쿼리
+- `internal/repository/usage_repository.go` — sqlc-backed 구현체
+- `internal/usecase/usage_usecase.go` — gap-fill / by-model / limits / from-to 검증
+- `internal/api/usage_handler.go` — 3개 핸들러
+- 테스트: `internal/usecase/usage_usecase_test.go`, `internal/repository/usage_repository_test.go`, `internal/api/usage_handler_test.go`, `internal/usecase/budget_usecase_cost_test.go`
+
+---
+
+## 1. 단계별 작업
+
+### Step 1 — Migration
+
+**파일**: `migrations/000004_add_cost_columns_to_tasks.up.sql`
+```sql
+ALTER TABLE tasks ADD COLUMN cost_usd                       REAL    NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN total_input_tokens             INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN total_output_tokens            INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN cache_creation_input_tokens    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN cache_read_input_tokens        INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN model_usage_json               TEXT    NOT NULL DEFAULT '{}';
+```
+
+`000004_*.down.sql`:
+```sql
+ALTER TABLE tasks DROP COLUMN model_usage_json;
+ALTER TABLE tasks DROP COLUMN cache_read_input_tokens;
+ALTER TABLE tasks DROP COLUMN cache_creation_input_tokens;
+ALTER TABLE tasks DROP COLUMN total_output_tokens;
+ALTER TABLE tasks DROP COLUMN total_input_tokens;
+ALTER TABLE tasks DROP COLUMN cost_usd;
+```
+
+> 인덱스 추가는 v1 보류 (10k 기준 OK). PRD §7 — 100k 임계 시 `idx_tasks_status_finished_at` 검토.
+
+> 기존 `estimated_input_tokens` / `estimated_output_tokens` 컬럼은 **유지**. 신규 컬럼이 권위있는 값.
+
+**수락 기준**
+- migrate up/down 정상 적용
+- 기존 task row 들이 영향 없이 cost_usd=0, model_usage_json='{}' 로 초기화
+
+**Sub-agent**: `go-generator`
+
+### Step 2 — Domain
+
+**작업 내용**
+1. `internal/domain/task.go`:
+   ```go
+   type Task struct {
+       // ... 기존 ...
+       CostUSD                  float64
+       TotalInputTokens         int64
+       TotalOutputTokens        int64
+       CacheCreationInputTokens int64
+       CacheReadInputTokens     int64
+       ModelUsageJSON           string  // 원본 JSON, 빈 값은 "{}"
+   }
+   ```
+2. `internal/domain/repository.go`:
+   ```go
+   type UsageRepository interface {
+       SumByBucket(ctx context.Context, from, to time.Time, bucket BucketKind) ([]UsageBucketRow, error)
+       SumByModel(ctx context.Context, from, to time.Time) ([]UsageModelRow, error)
+       SumDailyCost(ctx context.Context, dayKey string) (float64, error)
+       SumWeeklyCost(ctx context.Context, weekKey string) (float64, error)
+   }
+
+   type BucketKind string
+   const (
+       BucketDay   BucketKind = "day"
+       BucketWeek  BucketKind = "week"
+       BucketMonth BucketKind = "month"
+   )
+
+   type UsageBucketRow struct {
+       Bucket               string
+       TaskCount            int64
+       CostUSD              float64
+       InputTokens          int64
+       OutputTokens         int64
+       CacheReadTokens      int64
+       CacheCreationTokens  int64
+       FailedCostUSD        float64
+   }
+
+   type UsageModelRow struct {
+       ModelID              string
+       TaskCount            int64
+       CostUSD              float64
+       InputTokens          int64
+       OutputTokens         int64
+       CacheReadTokens      int64
+       CacheCreationTokens  int64
+   }
+   ```
+
+**수락 기준**
+- domain 패키지가 외부 패키지 import 안 함
+- `go vet` 통과
+
+**Sub-agent**: `go-modifier`
+
+### Step 3 — Repository (sqlc)
+
+**작업 내용**
+1. `db/query/usage.sql`:
+   ```sql
+   -- name: SumUsageByDay :many
+   SELECT
+       date(COALESCE(finished_at, created_at)) AS bucket,
+       COUNT(*) FILTER (WHERE status = 'done')          AS task_count,
+       COALESCE(SUM(cost_usd) FILTER (WHERE status = 'done'), 0) AS cost_usd,
+       COALESCE(SUM(total_input_tokens) FILTER (WHERE status = 'done'), 0)             AS input_tokens,
+       COALESCE(SUM(total_output_tokens) FILTER (WHERE status = 'done'), 0)            AS output_tokens,
+       COALESCE(SUM(cache_read_input_tokens) FILTER (WHERE status = 'done'), 0)        AS cache_read_tokens,
+       COALESCE(SUM(cache_creation_input_tokens) FILTER (WHERE status = 'done'), 0)    AS cache_creation_tokens,
+       COALESCE(SUM(cost_usd) FILTER (WHERE status IN ('failed','cancelled')), 0)      AS failed_cost_usd
+   FROM tasks
+   WHERE COALESCE(finished_at, created_at) >= ?
+     AND COALESCE(finished_at, created_at) <  ?
+   GROUP BY bucket
+   ORDER BY bucket;
+
+   -- name: SumUsageByWeek  :many   (strftime('%Y-W%W', ...))
+   -- name: SumUsageByMonth :many   (strftime('%Y-%m',  ...))
+
+   -- name: SumUsageByModel :many
+   --   model_usage_json 을 application-side scan 으로 합산 (PRD §10 R2 — v1 application-side OK)
+   --   sqlc 는 SELECT 만 하고 application 에서 JSON 펼치기 (이 쿼리는 SELECT cost_usd, model_usage_json 만)
+   SELECT cost_usd, model_usage_json,
+          total_input_tokens, total_output_tokens,
+          cache_read_input_tokens, cache_creation_input_tokens
+     FROM tasks
+    WHERE status = 'done'
+      AND COALESCE(finished_at, created_at) >= ?
+      AND COALESCE(finished_at, created_at) <  ?;
+
+   -- name: SumDailyCost  :one  (status='done' AND day key)
+   -- name: SumWeeklyCost :one
+   ```
+2. `sqlc generate` → `db/sqlc/` 자동 갱신
+3. `internal/repository/usage_repository.go`:
+   - `SumByBucket(BucketDay)` → `SumUsageByDay` 호출 후 `[]UsageBucketRow` 매핑
+   - `SumByBucket(BucketWeek)` → `SumUsageByWeek`
+   - `SumByBucket(BucketMonth)` → `SumUsageByMonth`
+   - `SumByModel` → `SumUsageByModel` 결과 row 마다 `model_usage_json` 을 `map[string]ModelUsageEntry` 로 unmarshal → application-side group-by 로 모델별 합산
+4. `internal/repository/task_repository.go` 의 `gormTask` 에 6개 컬럼 매핑 추가
+
+**수락 기준**
+- sqlc generate 무에러
+- 통합 테스트 (sqlite seed):
+  - 같은 일자 done task 3건 → bucket 1개, task_count=3, cost_usd 합 일치 (±0.001)
+  - failed task 의 cost 는 `failed_cost_usd` 로만 합산
+  - 빈 기간 → 빈 슬라이스 (gap-fill 은 usecase 책임)
+  - by-model: model 2개 task 5건 → cost_usd 내림차순, modelID="" → "unknown" 으로 합산
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 4 — UseCase
+
+**작업 내용**
+1. `internal/usecase/usage_usecase.go`:
+   ```go
+   type UsageUseCase interface {
+       Aggregate(ctx, from, to time.Time, bucket BucketKind) (UsageResult, error)
+       ByModel(ctx, from, to time.Time) ([]UsageModelRow, error)
+       Limits(ctx, now time.Time) (LimitsSnapshot, error)
+   }
+   ```
+2. `Aggregate`:
+   - `from > to` → `ErrInvalidRange`
+   - 기간 > 365일 → `ErrRangeTooLarge`
+   - `BucketKind` enum 검증 → `ErrInvalidBucket`
+   - 기본값: `to = now date`, `from = to - 30d`
+   - repo 호출 → **gap-fill**: 빈 일/주/월도 0 으로 채워 반환 (timezone = config.Schedule.ResetTZ 기준 — `BudgetCounters.DailyKey/WeeklyKey/MonthlyKey` 재사용)
+   - `totals` 합계 계산
+3. `Limits`:
+   - `dayKey := budgetCounters.DailyKey(now)`, `weekKey := budgetCounters.WeeklyKey(now)`
+   - `repo.SumDailyCost(dayKey)`, `repo.SumWeeklyCost(weekKey)`
+   - `max=0 → percent=null`, 그 외 `percent = round(cur/max*100, 1)`
+4. `internal/usecase/budget_usecase.go` 확장:
+   - `EvaluateCostWarn(ctx, now)` → cost_warn_state 영속 (AppState `cost_warn_state` 키 — daily/weekly_key, daily/weekly_warned_80/100)
+   - 키가 바뀌면 (`now` 가 새 일/주에 진입) 플래그 리셋
+   - `[80, 100)` 진입 + `daily_warned_80=false` → Slack `:warning:` 발송 + 플래그 set (발송 실패해도 set — R3)
+   - `>= 100` + `daily_warned_100=false` → Slack `:rotating_light:` 발송 + 플래그 set
+   - `daily_max_cost_usd == 0` → no-op
+
+**수락 기준**
+- mockery `UsageRepository` mock 후 단위 테스트:
+  - happy path day/week/month 각 케이스
+  - gap-fill: 비어있는 중간 일자 0 으로 채워짐 (`2026-W17` 빠짐 없이 출력)
+  - `from > to` → 400 에러
+  - 365일 초과 → 400
+  - by-model: cost_usd 내림차순, modelID 빈 값 → "unknown" 합산
+  - limits: max=0 → percent=null
+  - cost warn:
+    - 70% → 발송 0회
+    - 70 → 85 진입 → :warning: 1회
+    - 같은 날 다시 평가 → 발송 0회 (daily_warned_80=true)
+    - 85 → 105 진입 → :rotating_light: 1회 (warned_80 은 이미 true 라 추가 발송 없음)
+    - 다음 날 (dayKey 변경) → 플래그 리셋, 다시 80% 진입 시 발송
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 5 — Worker 통합 (cost / modelUsage 영속화 + warn 트리거)
+
+**작업 내용**
+1. `internal/claude/stream/parser.go` — `ResultEvent` 가 이미 `TotalCostUSD`, `Usage`, `ModelUsage` 파싱 중인지 확인 → 미흡 시 보강 (Signal.Result 에 ModelUsage map 통과)
+2. `internal/claude/runner.go` — `RunResult` 에 `ModelUsage map[string]ModelUsageEntry` (혹은 raw JSON string) 필드 추가, parser → runner → worker 까지 전달
+3. `internal/scheduler/worker.go` `applyRunUsage` (또는 동등):
+   - 기존: `EstimatedInputTokens` / `EstimatedOutputTokens` 만 set
+   - 추가: `task.CostUSD = result.TotalCostUSD`, `task.TotalInputTokens = result.Usage.InputTokens`, `Output...`, `CacheCreation/Read...`, `task.ModelUsageJSON = json.Marshal(result.ModelUsage)` (빈 map 이면 `"{}"`)
+   - `result` 미수신 (crash 등) → 0 / "{}" 유지 (Update 호출 안 하면 default 유지)
+4. markDone 직전 `Update(task)` → 영속화
+5. markDone 이후 `budgetUC.EvaluateCostWarn(ctx, now)` 호출 — Slack 발송 트리거
+
+**수락 기준**
+- worker 단위 테스트 (mock Runner / mock Repo):
+  - result.TotalCostUSD=0.5 → task.CostUSD=0.5 로 Update 호출
+  - result.ModelUsage 비어있음 → task.ModelUsageJSON="{}"
+  - result 미수신 (Run 에러) → CostUSD=0 유지, status=failed
+  - cost warn 80% 진입 케이스에서 `slackClient.NotifyCostWarning` 1회 호출
+- 회귀: 기존 worker happy path 테스트 모두 통과 (estimated tokens 도 여전히 set)
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-modifier` + `go-tester`
+
+### Step 6 — Handler (Gin + swag godoc)
+
+**작업 내용**
+1. `internal/api/usage_handler.go`:
+   ```go
+   // GetUsage returns a time-series usage aggregation.
+   //
+   // @Summary  Aggregated usage by bucket
+   // @Tags     usage
+   // @Param    from     query string false "ISO date YYYY-MM-DD"
+   // @Param    to       query string false "ISO date YYYY-MM-DD"
+   // @Param    group_by query string false "day|week|month" Enums(day, week, month)
+   // @Success  200 {object} api.UsageResponse
+   // @Failure  400 {object} api.ErrorResponse
+   // @Router   /usage [get]
+   func (h *UsageHandler) GetUsage(c *gin.Context) { ... }
+
+   // GetUsageByModel returns per-model usage aggregation.
+   // @Router /usage/by-model [get]
+   func (h *UsageHandler) GetUsageByModel(c *gin.Context) { ... }
+
+   // GetUsageLimits returns current vs configured cost limits.
+   // @Router /usage/limits [get]
+   func (h *UsageHandler) GetUsageLimits(c *gin.Context) { ... }
+   ```
+2. `internal/api/dto.go` — DTO + 모든 필드에 `example:"..."` 태그 (PRD §8 응답 예시 그대로)
+3. `internal/api/server.go` — 3개 라우트 등록
+4. domain error → HTTP status 매핑:
+   - `ErrInvalidRange`, `ErrInvalidBucket`, `ErrRangeTooLarge` → 400
+   - 그 외 → 500 (slog.Error)
+
+**수락 기준**
+- httptest:
+  - `GET /usage` 누락 query → 기본값 (to=today, from=to-30d, group_by=day) 응답 200
+  - `GET /usage?from=invalid` → 400
+  - `GET /usage?group_by=year` → 400
+  - `GET /usage?group_by=week&from=2026-01-01&to=2026-04-27` → 200, buckets[].bucket 이 ISO week 형식
+  - `GET /usage/by-model` → cost_usd 내림차순
+  - `GET /usage/limits` → max=0 일 때 percent=null (json 출력 검증)
+- swag init 후 `/swagger/index.html` 에 3개 라우트 + 모든 DTO 예시 노출
+- p95 < 200ms 검증 (10k seed task 로 로컬 측정 — 별도 벤치 권장)
+- 커버리지 ≥ 85%
+
+**Sub-agent**: `go-generator` + `go-tester`
+
+### Step 7 — DI 조립 (`cmd/scheduled-dev-agent/main.go`)
+
+**작업 내용**
+- `usageRepo := repository.NewUsageRepository(db, sqlcQueries)`
+- `usageUC := usecase.NewUsageUseCase(usageRepo, &cfg.Schedule, &cfg.Limits)`
+- `budgetUC` 에 `usageRepo` + `slackClient` 주입 (cost warn 평가용)
+- `usageHandler := api.NewUsageHandler(usageUC)`
+- `server.go` 에서 라우트 등록
+
+**수락 기준**
+- `go build ./...` 통과
+- `limits.daily_max_cost_usd=0` 부팅 → cost warn 비활성화 (worker 가 평가 호출은 하되 no-op)
+
+**Sub-agent**: `go-modifier`
+
+### Step 8 — 검증
+
+```bash
+sqlc generate
+mockery --name=UsageRepository --dir=internal/domain --output=mocks
+mockery --name=SlackClient     --dir=internal/slack  --output=mocks
+go build ./...
+go test -race -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out | tail -1                          # ≥80%
+go tool cover -func=coverage.out | grep -E '(usage_usecase|usage_repository|budget_usecase)'  # ≥85%
+go vet ./...
+golangci-lint run ./...
+swag init -g cmd/scheduled-dev-agent/main.go -o docs
+```
+
+**수락 기준 (전체 게이트)**
+- 모든 명령 0 exit
+- `.claude/hooks/pre-push.sh` 통과
+- swagger 에 `/usage`, `/usage/by-model`, `/usage/limits` + 모든 신규 DTO 노출
+- 회귀: 기존 `/tasks`, `/modes/*` 응답 스키마 변경 0건 (필드 추가 없음 — usage-dashboard 는 별도 라우트)
+
+---
+
+## 2. PRD 수락 기준 매핑
+
+| PRD Goal | 검증 |
+|----------|------|
+| G1. result 이벤트 → 6개 필드 100% 영속 | worker_test 의 모든 happy path 케이스 |
+| G2. /usage p95 < 200ms (10k 기준) | sqlite seed 10k → 로컬 측정 + 단위 테스트 latency 가드 |
+| G3. by-model 분해 | usage_handler_test + by-model 응답 검증 |
+| G4. 80%/100% Slack warn 1회만 | budget_usecase_test 의 멱등 시나리오 |
+| G5. 기존 게이트 회귀 0건 | scheduler/budget_gate 회귀 테스트 통과 |
+
+| PRD User Story | 검증 |
+|----------------|------|
+| US-1 (영속화) | worker_test |
+| US-2 (시계열 집계 + gap-fill) | usage_usecase_test gap-fill 케이스 |
+| US-3 (by-model) | by-model 단위 + 핸들러 |
+| US-4 (limits) | limits 단위 + max=0 케이스 |
+| US-5 (Slack 경고) | budget_usecase_test 80/100% 멱등 |
+| US-6 (Swagger) | swag init 산출물 검증 |
+
+---
+
+## 3. CLAUDE.md NEVER 체크리스트
+
+- [ ] `domain/` 외부 패키지 import 금지 — Task 의 신규 필드는 모두 primitive
+- [ ] raw SQL 금지 — `db/query/usage.sql` + sqlc generate
+- [ ] 전역 var db 금지 — `cmd/main.go` DI 만
+- [ ] `context.Background()` 핸들러 직접 사용 금지 — 모든 핸들러 `c.Request.Context()`
+- [ ] swag 주석 없는 endpoint 추가 금지 — 3개 모두 godoc
+- [ ] 기존 migration 수정 금지 — 000004 신규만
+- [ ] 테스트 없이 UseCase 메서드 추가 금지 — Aggregate / ByModel / Limits / EvaluateCostWarn 모두 단위 테스트 동시 추가
+- [ ] `db/sqlc/` 수동 수정 금지 — sqlc generate 만
+- [ ] `panic()` 금지 — 모든 경로 에러 반환
+- [ ] secret/PII 로그 금지 — cost·token 수치는 PII 아니지만 model_usage_json 원본은 로그 무덤프
+
+---
+
+## 4. OI / 후속 결정 (PRD §12 와 동기화)
+
+- **OI-1**: `COALESCE(finished_at, created_at)` 채택 (sqlc 쿼리에 반영) — PRD v1 결정값
+- **OI-2**: 정규화 시점은 100k 임계 도달 시 별도 PRD. v1 은 application-side scan 유지
+- **OI-3**: `/usage/by-model` 별도 엔드포인트 채택. `?breakdown=model` 쿼리 옵션은 v1 미구현
+- **OI-4**: 80%/100% 임계 고정. config 외부화는 v2
+- **OI-5**: ISO week 통일 (`2026-W17` 형식, `BudgetCounters.WeeklyKey` 재사용)
+- **OI-6**: dispatch 차단은 v2 — 본 PRD 는 경고만
+
+---
+
+## 5. 후속 수동 작업
+
+```bash
+# 마이그레이션 적용
+go run ./cmd/scheduled-dev-agent migrate up   # 또는 사용 중인 migrate 명령
+
+# config.example.yaml 에 limits 추가
+limits:
+  daily_max_cost_usd:  1.00
+  weekly_max_cost_usd: 5.00
+
+# README "Cost & Usage" 섹션 추가 — `/usage`, `/usage/by-model`, `/usage/limits` 사용 예시 포함
+```

--- a/internal/api/dto.go
+++ b/internal/api/dto.go
@@ -112,3 +112,10 @@ type LimitsPatchRequest struct {
 	DailyMax  *int `json:"daily_max,omitempty" example:"5"`
 	WeeklyMax *int `json:"weekly_max,omitempty" example:"35"`
 }
+
+// WebhookResponse is the response for POST /github/webhook.
+type WebhookResponse struct {
+	Accepted bool   `json:"accepted" example:"true"`
+	Reason   string `json:"reason,omitempty" example:"queued"`
+	TaskID   string `json:"task_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
+}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -313,6 +313,38 @@ func TestSlackInteractionsEndpoint_InvalidSignature(t *testing.T) {
 	}
 }
 
+// TestRouter_WebhookDisabled_404 verifies that when webhookHandler is nil
+// (secret not configured), POST /github/webhook returns 404 — the endpoint is not registered. // ADDED
+func TestRouter_WebhookDisabled_404(t *testing.T) { // ADDED
+	canceller := &fakeCanceller{}
+	taskRepo := &fakeTaskRepo{}
+	appStateRepo := &fakeAppStateRepo{}
+	taskUC := usecase.NewTaskUseCase(taskRepo, &fakeEventRepo{}, appStateRepo, canceller, nil)
+	modeUC := usecase.NewModeUseCase(appStateRepo)
+
+	budgetUC := usecase.NewBudgetUseCase(appStateRepo, scheduler.BudgetLimits{})
+
+	healthH := api.NewHealthHandler(modeUC)
+	taskH := api.NewTaskHandler(taskUC)
+	modeH := api.NewModeHandler(modeUC)
+	limitsH := api.NewLimitsHandler(budgetUC)
+	slackH := api.NewSlackHandler("test-secret", canceller)
+
+	// Pass nil as webhookHandler to simulate secret not configured.
+	r := api.NewRouter(healthH, taskH, modeH, limitsH, slackH, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewBufferString("{}"))
+	req.Header.Set("X-GitHub-Event", "ping")
+	req.Header.Set("X-GitHub-Delivery", "some-uuid")
+	req.Header.Set("X-Hub-Signature-256", "sha256=irrelevant")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound { // ADDED
+		t.Errorf("expected 404 when webhook is disabled (nil handler), got %d", w.Code) // ADDED
+	}
+}
+
 // TestServer_Shutdown_C4 verifies C4 fix: Shutdown actually delegates to http.Server.Shutdown
 // and does not return a no-op nil when the server has started.
 func TestServer_Shutdown_C4(t *testing.T) { // ADDED

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -100,6 +100,13 @@ type fakeCanceller struct{}
 
 func (c *fakeCanceller) CancelTask(_ context.Context, _ string) error { return nil }
 
+// fakeWebhookHandler is a no-op webhook handler for tests that don't need webhook logic.
+type fakeWebhookHandler struct{}
+
+func (f *fakeWebhookHandler) HandleWebhook(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}
+
 func setupRouter(taskRepo *fakeTaskRepo, appStateRepo *fakeAppStateRepo) *gin.Engine {
 	canceller := &fakeCanceller{}
 	taskUC := usecase.NewTaskUseCase(taskRepo, &fakeEventRepo{}, appStateRepo, canceller, nil)
@@ -112,7 +119,7 @@ func setupRouter(taskRepo *fakeTaskRepo, appStateRepo *fakeAppStateRepo) *gin.En
 	limitsH := api.NewLimitsHandler(budgetUC)
 	slackH := api.NewSlackHandler("test-secret", canceller)
 
-	return api.NewRouter(healthH, taskH, modeH, limitsH, slackH)
+	return api.NewRouter(healthH, taskH, modeH, limitsH, slackH, &fakeWebhookHandler{})
 }
 
 func TestHealthEndpoint(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GitHubWebhookHandler is the interface for the GitHub webhook handler.
+type GitHubWebhookHandler interface {
+	HandleWebhook(c *gin.Context)
+}
+
 // NewRouter creates and configures a Gin router with all handlers.
 func NewRouter(
 	healthHandler *HealthHandler,
@@ -14,6 +19,7 @@ func NewRouter(
 	modeHandler *ModeHandler,
 	limitsHandler *LimitsHandler,
 	slackHandler *SlackHandler,
+	webhookHandler GitHubWebhookHandler,
 ) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
@@ -42,6 +48,11 @@ func NewRouter(
 
 	// Slack
 	r.POST("/slack/interactions", slackHandler.HandleInteractions)
+
+	// GitHub webhook — registered only when handler is provided (secret configured).
+	if webhookHandler != nil {
+		r.POST("/github/webhook", webhookHandler.HandleWebhook)
+	}
 
 	return r
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,9 +103,10 @@ type SlackConfig struct {
 
 // Env holds sensitive values loaded from environment variables.
 type Env struct {
-	GitHubToken        string
-	SlackBotToken      string
-	SlackSigningSecret string
+	GitHubToken         string
+	GitHubWebhookSecret string
+	SlackBotToken       string
+	SlackSigningSecret  string
 }
 
 // Load reads the YAML config file, loads .env from the working directory (if present),
@@ -157,9 +158,10 @@ func LoadEnv() (*Env, error) {
 	_ = godotenv.Load()
 
 	env := &Env{
-		GitHubToken:        os.Getenv("GITHUB_TOKEN"),
-		SlackBotToken:      os.Getenv("SLACK_BOT_TOKEN"),
-		SlackSigningSecret: os.Getenv("SLACK_SIGNING_SECRET"),
+		GitHubToken:         os.Getenv("GITHUB_TOKEN"),
+		GitHubWebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),
+		SlackBotToken:       os.Getenv("SLACK_BOT_TOKEN"),
+		SlackSigningSecret:  os.Getenv("SLACK_SIGNING_SECRET"),
 	}
 	return env, nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -214,7 +214,7 @@ func (e *Env) ValidateEnv() error {
 		return fmt.Errorf("SLACK_SIGNING_SECRET environment variable is required")
 	}
 	if e.GitHubWebhookSecret == "" {
-		slog.Warn("github webhook disabled: GITHUB_WEBHOOK_SECRET not set — POST /github/webhook will return 503")
+		slog.Warn("GITHUB_WEBHOOK_SECRET unset — /github/webhook endpoint will not be registered") // MODIFIED
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -211,6 +212,9 @@ func (e *Env) ValidateEnv() error {
 	}
 	if e.SlackSigningSecret == "" {
 		return fmt.Errorf("SLACK_SIGNING_SECRET environment variable is required")
+	}
+	if e.GitHubWebhookSecret == "" {
+		slog.Warn("github webhook disabled: GITHUB_WEBHOOK_SECRET not set — POST /github/webhook will return 503")
 	}
 	return nil
 }

--- a/internal/github/webhook_dedup.go
+++ b/internal/github/webhook_dedup.go
@@ -22,9 +22,10 @@ type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now() }
 
-// memDedupCache is an in-memory DedupCache backed by sync.Map with TTL eviction.
+// memDedupCache is an in-memory DedupCache backed by a mutex-protected map with TTL eviction. // MODIFIED
 type memDedupCache struct {
-	items sync.Map // map[string]time.Time (expiresAt)
+	mu    sync.Mutex           // MODIFIED: replaced sync.Map with mutex + plain map
+	items map[string]time.Time // MODIFIED: deliveryID → expiresAt
 	ttl   time.Duration
 	clock Clock
 }
@@ -37,32 +38,25 @@ func NewMemDedupCache(ctx context.Context, ttl time.Duration) DedupCache {
 
 // NewMemDedupCacheWithClock creates a MemDedupCache with an injected clock (for testing).
 func NewMemDedupCacheWithClock(ctx context.Context, ttl time.Duration, clk Clock) *memDedupCache {
-	c := &memDedupCache{ttl: ttl, clock: clk}
+	c := &memDedupCache{ttl: ttl, clock: clk, items: make(map[string]time.Time)} // MODIFIED
 	go c.gcLoop(ctx)
 	return c
 }
 
 // CheckAndAdd returns true if deliveryID is new (and records it), false if it is a duplicate.
+// The entire check-and-store is performed under the mutex to eliminate the TOCTOU race
+// that existed with the previous LoadOrStore → TTL check → Store pattern. // MODIFIED
 func (c *memDedupCache) CheckAndAdd(deliveryID string) bool {
+	c.mu.Lock()         // MODIFIED
+	defer c.mu.Unlock() // MODIFIED
 	now := c.clock.Now()
-	expiresAt := now.Add(c.ttl)
-
-	// LoadOrStore is atomic: if key already exists, return the existing value.
-	existing, loaded := c.items.LoadOrStore(deliveryID, expiresAt)
-	if !loaded {
-		// First time seen.
-		return true
+	if exp, ok := c.items[deliveryID]; ok && now.Before(exp) { // MODIFIED
+		// Within TTL — it's a duplicate.
+		return false
 	}
-
-	// Key exists; check whether the existing entry has expired.
-	if exp, ok := existing.(time.Time); ok && now.After(exp) {
-		// Entry is expired — overwrite and accept.
-		c.items.Store(deliveryID, expiresAt)
-		return true
-	}
-
-	// Within TTL — it's a duplicate.
-	return false
+	// First time seen, or TTL has expired — accept and record.
+	c.items[deliveryID] = now.Add(c.ttl) // MODIFIED
+	return true
 }
 
 // gcLoop removes expired entries every 60 seconds until ctx is done.
@@ -80,13 +74,14 @@ func (c *memDedupCache) gcLoop(ctx context.Context) {
 }
 
 func (c *memDedupCache) evictExpired() {
+	c.mu.Lock()         // MODIFIED
+	defer c.mu.Unlock() // MODIFIED
 	now := c.clock.Now()
-	c.items.Range(func(key, value any) bool {
-		if exp, ok := value.(time.Time); ok && now.After(exp) {
-			c.items.Delete(key)
+	for key, exp := range c.items { // MODIFIED
+		if now.After(exp) {
+			delete(c.items, key) // MODIFIED
 		}
-		return true
-	})
+	}
 }
 
 // EvictExpiredForTesting exposes evictExpired for white-box testing of GC behaviour.

--- a/internal/github/webhook_dedup.go
+++ b/internal/github/webhook_dedup.go
@@ -1,0 +1,95 @@
+package github
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// DedupCache prevents double-processing the same webhook delivery.
+type DedupCache interface {
+	// CheckAndAdd returns true (accepted) if deliveryID is new, false (duplicate) if already seen.
+	CheckAndAdd(deliveryID string) bool
+}
+
+// Clock abstracts time.Now() for testable TTL logic.
+type Clock interface {
+	Now() time.Time
+}
+
+// realClock returns real system time.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// memDedupCache is an in-memory DedupCache backed by sync.Map with TTL eviction.
+type memDedupCache struct {
+	items sync.Map // map[string]time.Time (expiresAt)
+	ttl   time.Duration
+	clock Clock
+}
+
+// NewMemDedupCache creates a MemDedupCache that evicts entries after ttl.
+// A background GC goroutine runs every 60s and stops when ctx is cancelled.
+func NewMemDedupCache(ctx context.Context, ttl time.Duration) DedupCache {
+	return NewMemDedupCacheWithClock(ctx, ttl, realClock{})
+}
+
+// NewMemDedupCacheWithClock creates a MemDedupCache with an injected clock (for testing).
+func NewMemDedupCacheWithClock(ctx context.Context, ttl time.Duration, clk Clock) *memDedupCache {
+	c := &memDedupCache{ttl: ttl, clock: clk}
+	go c.gcLoop(ctx)
+	return c
+}
+
+// CheckAndAdd returns true if deliveryID is new (and records it), false if it is a duplicate.
+func (c *memDedupCache) CheckAndAdd(deliveryID string) bool {
+	now := c.clock.Now()
+	expiresAt := now.Add(c.ttl)
+
+	// LoadOrStore is atomic: if key already exists, return the existing value.
+	existing, loaded := c.items.LoadOrStore(deliveryID, expiresAt)
+	if !loaded {
+		// First time seen.
+		return true
+	}
+
+	// Key exists; check whether the existing entry has expired.
+	if exp, ok := existing.(time.Time); ok && now.After(exp) {
+		// Entry is expired — overwrite and accept.
+		c.items.Store(deliveryID, expiresAt)
+		return true
+	}
+
+	// Within TTL — it's a duplicate.
+	return false
+}
+
+// gcLoop removes expired entries every 60 seconds until ctx is done.
+func (c *memDedupCache) gcLoop(ctx context.Context) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.evictExpired()
+		}
+	}
+}
+
+func (c *memDedupCache) evictExpired() {
+	now := c.clock.Now()
+	c.items.Range(func(key, value any) bool {
+		if exp, ok := value.(time.Time); ok && now.After(exp) {
+			c.items.Delete(key)
+		}
+		return true
+	})
+}
+
+// EvictExpiredForTesting exposes evictExpired for white-box testing of GC behaviour.
+func (c *memDedupCache) EvictExpiredForTesting() {
+	c.evictExpired()
+}

--- a/internal/github/webhook_dedup_test.go
+++ b/internal/github/webhook_dedup_test.go
@@ -1,0 +1,155 @@
+package github_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
+)
+
+// fakeClock is a Clock implementation whose current time is settable.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(t time.Time) *fakeClock { return &fakeClock{now: t} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func TestDedupCache_NewDelivery_Accepted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, newFakeClock(time.Now()))
+	if !cache.CheckAndAdd("delivery-1") {
+		t.Error("first delivery should be accepted")
+	}
+}
+
+func TestDedupCache_DuplicateWithinTTL_Rejected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clk := newFakeClock(time.Now())
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, clk)
+
+	if !cache.CheckAndAdd("delivery-2") {
+		t.Fatal("first call must be accepted")
+	}
+	// Advance 1 minute — still within 5-minute TTL.
+	clk.Advance(1 * time.Minute)
+	if cache.CheckAndAdd("delivery-2") {
+		t.Error("duplicate within TTL should be rejected")
+	}
+}
+
+func TestDedupCache_AfterTTL_Accepted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clk := newFakeClock(time.Now())
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, clk)
+
+	if !cache.CheckAndAdd("delivery-3") {
+		t.Fatal("first call must be accepted")
+	}
+	// Advance past 5-minute TTL.
+	clk.Advance(5*time.Minute + 1*time.Second)
+	if !cache.CheckAndAdd("delivery-3") {
+		t.Error("same ID after TTL expiry should be accepted again")
+	}
+}
+
+// TestDedupCache_Concurrent_ExactlyOneAccepted verifies that under concurrent load,
+// exactly one goroutine wins the CheckAndAdd race for the same delivery ID.
+func TestDedupCache_Concurrent_ExactlyOneAccepted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, newFakeClock(time.Now()))
+
+	const goroutines = 1000
+	var accepted atomic.Int64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			if cache.CheckAndAdd("shared-delivery") {
+				accepted.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if accepted.Load() != 1 {
+		t.Errorf("expected exactly 1 acceptance, got %d", accepted.Load())
+	}
+}
+
+func TestDedupCache_DifferentIDs_BothAccepted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, newFakeClock(time.Now()))
+
+	if !cache.CheckAndAdd("delivery-A") {
+		t.Error("delivery-A should be accepted")
+	}
+	if !cache.CheckAndAdd("delivery-B") {
+		t.Error("delivery-B should be accepted")
+	}
+}
+
+// TestDedupCache_NewMemDedupCache_WithRealClock tests the public constructor
+// that uses the real system clock, ensuring it can be created and used.
+func TestDedupCache_NewMemDedupCache_WithRealClock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := igithub.NewMemDedupCache(ctx, 5*time.Minute)
+	if !cache.CheckAndAdd("real-clock-delivery") {
+		t.Error("first delivery should be accepted")
+	}
+	if cache.CheckAndAdd("real-clock-delivery") {
+		t.Error("duplicate within TTL should be rejected")
+	}
+}
+
+// TestDedupCache_EvictExpired exercises the GC eviction path directly.
+func TestDedupCache_EvictExpired(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clk := newFakeClock(time.Now())
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, clk)
+
+	if !cache.CheckAndAdd("evict-target") {
+		t.Fatal("first call must be accepted")
+	}
+	// Advance past TTL.
+	clk.Advance(5*time.Minute + 1*time.Second)
+
+	// Trigger GC directly.
+	cache.EvictExpiredForTesting()
+
+	// After eviction, the entry should be gone and accepted again (not via TTL bypass).
+	if !cache.CheckAndAdd("evict-target") {
+		t.Error("evicted entry should be accepted after GC removes it")
+	}
+}

--- a/internal/github/webhook_dedup_test.go
+++ b/internal/github/webhook_dedup_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
+	igithub "github.com/gs97ahn/claude-ops/internal/github"
 )
 
 // fakeClock is a Clock implementation whose current time is settable.
@@ -128,6 +128,45 @@ func TestDedupCache_NewMemDedupCache_WithRealClock(t *testing.T) {
 	}
 	if cache.CheckAndAdd("real-clock-delivery") {
 		t.Error("duplicate within TTL should be rejected")
+	}
+}
+
+// TestDedupCache_TTLBoundary_ExactlyOneAccepted verifies that when the TTL has just expired
+// and 100 goroutines simultaneously call CheckAndAdd with the same delivery ID,
+// exactly one goroutine wins the race and gets true.
+func TestDedupCache_TTLBoundary_ExactlyOneAccepted(t *testing.T) { // ADDED
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clk := newFakeClock(time.Now())
+	cache := igithub.NewMemDedupCacheWithClock(ctx, 5*time.Minute, clk)
+
+	// t=0: register the delivery ID.
+	if !cache.CheckAndAdd("boundary-delivery") {
+		t.Fatal("first call must be accepted")
+	}
+
+	// Advance past TTL so the entry is expired.
+	clk.Advance(5*time.Minute + 1*time.Millisecond)
+
+	// 100 goroutines race to CheckAndAdd the same expired ID — exactly 1 must win.
+	const goroutines = 100
+	var accepted atomic.Int64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			if cache.CheckAndAdd("boundary-delivery") {
+				accepted.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if accepted.Load() != 1 {
+		t.Errorf("TTL boundary: expected exactly 1 acceptance, got %d", accepted.Load())
 	}
 }
 

--- a/internal/github/webhook_handler.go
+++ b/internal/github/webhook_handler.go
@@ -1,0 +1,274 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/gs97ahn/scheduled-dev-agent/internal/api"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/config"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/domain"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/usecase"
+)
+
+const maxBodyBytes = 1 << 20 // 1 MB
+
+// webhookTaskEnqueuer is the subset of TaskUseCase used by the webhook handler.
+type webhookTaskEnqueuer interface {
+	EnqueueFromIssue(ctx context.Context, req usecase.EnqueueRequest) (*domain.Task, error)
+}
+
+// webhookTaskChecker is the subset of TaskRepository used by the webhook handler.
+type webhookTaskChecker interface {
+	ExistsByRepoAndIssue(ctx context.Context, repoFullName string, issueNumber int) (bool, error)
+}
+
+// issueWebhookPayload is the subset of the GitHub IssueEvent JSON we care about.
+type issueWebhookPayload struct {
+	Action string `json:"action"`
+	Issue  struct {
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		PullRequest *struct {
+			URL string `json:"url"`
+		} `json:"pull_request,omitempty"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Label *struct {
+		Name string `json:"name"`
+	} `json:"label,omitempty"`
+}
+
+// WebhookHandler handles POST /github/webhook.
+type WebhookHandler struct {
+	verifier  *WebhookVerifier
+	dedup     DedupCache
+	taskUC    webhookTaskEnqueuer
+	taskRepo  webhookTaskChecker
+	githubCfg *config.GitHubConfig
+}
+
+// NewWebhookHandler creates a WebhookHandler.
+func NewWebhookHandler(
+	verifier *WebhookVerifier,
+	dedup DedupCache,
+	taskUC webhookTaskEnqueuer,
+	taskRepo webhookTaskChecker,
+	githubCfg *config.GitHubConfig,
+) *WebhookHandler {
+	return &WebhookHandler{
+		verifier:  verifier,
+		dedup:     dedup,
+		taskUC:    taskUC,
+		taskRepo:  taskRepo,
+		githubCfg: githubCfg,
+	}
+}
+
+// HandleWebhook ingests GitHub issue webhooks.
+//
+// @Summary  Receive GitHub webhook
+// @Tags     github
+// @Accept   json
+// @Param    X-Hub-Signature-256  header  string  true  "HMAC-SHA256 signature (sha256=<hex>)"
+// @Param    X-GitHub-Delivery    header  string  true  "Delivery UUID"
+// @Param    X-GitHub-Event       header  string  true  "Event type (issues, ping)"
+// @Success  200  {object}  api.WebhookResponse
+// @Failure  400  {object}  api.ErrorResponse
+// @Failure  401  {object}  api.ErrorResponse
+// @Failure  500  {object}  api.ErrorResponse
+// @Router   /github/webhook [post]
+func (h *WebhookHandler) HandleWebhook(c *gin.Context) {
+	start := time.Now()
+	ctx := c.Request.Context()
+
+	// Step 2: Read body with size cap.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBodyBytes)
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		slog.Warn("webhook: body read error", "err", err)
+		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "request body too large or unreadable"})
+		return
+	}
+
+	// Step 3: Validate required headers.
+	event := c.GetHeader("X-GitHub-Event")
+	if event == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "missing X-GitHub-Event header"})
+		return
+	}
+
+	// Step 4: Delivery ID.
+	delivery := c.GetHeader("X-GitHub-Delivery")
+	if delivery == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "missing X-GitHub-Delivery header"})
+		return
+	}
+
+	// Step 5: Signature header.
+	sig := c.GetHeader("X-Hub-Signature-256")
+	if sig == "" {
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "missing X-Hub-Signature-256 header"})
+		return
+	}
+
+	// Step 6: Verify HMAC-SHA256.
+	if verifyErr := h.verifier.Verify(body, sig); verifyErr != nil {
+		if errors.Is(verifyErr, ErrWebhookDisabled) {
+			// Webhook disabled but endpoint still called — return 503.
+			c.JSON(http.StatusServiceUnavailable, api.ErrorResponse{Error: "github webhook not configured"})
+			return
+		}
+		slog.Warn("webhook: signature verification failed", "delivery", delivery, "event", event)
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "signature verification failed"})
+		return
+	}
+
+	// Step 7: Handle ping.
+	if event == "ping" {
+		slog.Info("webhook: ping received", "delivery", delivery)
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: true, Reason: "ping"})
+		return
+	}
+
+	// Step 8: Only handle "issues" events.
+	if event != "issues" {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "ignored:event_not_supported"})
+		return
+	}
+
+	// Step 9: Dedup by delivery ID.
+	if !h.dedup.CheckAndAdd(delivery) {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "duplicate"})
+		return
+	}
+
+	// Step 10: Unmarshal payload.
+	var payload issueWebhookPayload
+	if jsonErr := json.Unmarshal(body, &payload); jsonErr != nil {
+		slog.Error("webhook: json unmarshal failed", "delivery", delivery, "err", jsonErr)
+		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "invalid JSON payload"})
+		return
+	}
+
+	// Step 11: Skip PR events.
+	if payload.Issue.PullRequest != nil {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "ignored:pr_event"})
+		return
+	}
+
+	// Step 12: Only handle opened / labeled actions.
+	if payload.Action != "opened" && payload.Action != "labeled" {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "ignored:action"})
+		return
+	}
+
+	// Step 13: Allowlist check.
+	repoFullName := payload.Repository.FullName
+	repoCfg, found := h.findRepoCfg(repoFullName)
+	if !found {
+		slog.Info("webhook: repo not in allowlist", "delivery", delivery, "repo", repoFullName)
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "ignored:not_in_allowlist"})
+		return
+	}
+
+	// Step 14: Label match.
+	issueLabels := make([]string, 0, len(payload.Issue.Labels))
+	for _, l := range payload.Issue.Labels {
+		issueLabels = append(issueLabels, l.Name)
+	}
+	if !hasAllLabelNames(issueLabels, repoCfg.Labels) {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "ignored:label_mismatch"})
+		return
+	}
+
+	issueNumber := payload.Issue.Number
+
+	// Step 15: Check for existing task (polling race).
+	exists, err := h.taskRepo.ExistsByRepoAndIssue(ctx, repoFullName, issueNumber)
+	if err != nil {
+		slog.Error("webhook: ExistsByRepoAndIssue failed", "delivery", delivery, "repo", repoFullName, "issue", issueNumber, "err", err)
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
+		return
+	}
+	if exists {
+		c.JSON(http.StatusOK, api.WebhookResponse{Accepted: false, Reason: "duplicate"})
+		return
+	}
+
+	// Step 16: Enqueue task.
+	taskID := uuid.New().String()
+	task, enqErr := h.taskUC.EnqueueFromIssue(ctx, usecase.EnqueueRequest{
+		RepoFullName: repoFullName,
+		IssueNumber:  issueNumber,
+		IssueTitle:   payload.Issue.Title,
+		Source:       "webhook",
+	})
+	if enqErr != nil {
+		// Step 17: INSERT failure → 500 so GitHub will retry.
+		slog.Error("webhook: enqueue failed", "delivery", delivery, "repo", repoFullName, "issue", issueNumber, "err", enqErr)
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
+		return
+	}
+	if task != nil {
+		taskID = task.ID
+	}
+
+	// Step 18: Success.
+	latencyMS := time.Since(start).Milliseconds()
+	slog.Info("webhook: accepted",
+		"event", event,
+		"action", payload.Action,
+		"delivery_id", delivery,
+		"repo", repoFullName,
+		"issue", issueNumber,
+		"accepted", true,
+		"reason", "queued",
+		"latency_ms", latencyMS,
+	)
+
+	c.JSON(http.StatusOK, api.WebhookResponse{
+		Accepted: true,
+		Reason:   "queued",
+		TaskID:   taskID,
+	})
+}
+
+// findRepoCfg searches the configured repos for a matching full name.
+func (h *WebhookHandler) findRepoCfg(fullName string) (config.RepoConfig, bool) {
+	for _, r := range h.githubCfg.Repos {
+		if r.Name == fullName {
+			return r, true
+		}
+	}
+	return config.RepoConfig{}, false
+}
+
+// hasAllLabelNames reports whether labelNames contains all of required.
+func hasAllLabelNames(labelNames, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(labelNames))
+	for _, l := range labelNames {
+		set[l] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := set[r]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/github/webhook_handler.go
+++ b/internal/github/webhook_handler.go
@@ -3,19 +3,17 @@ package github
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 
-	"github.com/gs97ahn/scheduled-dev-agent/internal/api"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/config"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/domain"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/usecase"
+	"github.com/gs97ahn/claude-ops/internal/api"
+	"github.com/gs97ahn/claude-ops/internal/config"
+	"github.com/gs97ahn/claude-ops/internal/domain"
+	"github.com/gs97ahn/claude-ops/internal/usecase"
 )
 
 const maxBodyBytes = 1 << 20 // 1 MB
@@ -125,12 +123,9 @@ func (h *WebhookHandler) HandleWebhook(c *gin.Context) {
 	}
 
 	// Step 6: Verify HMAC-SHA256.
+	// Note: ErrWebhookDisabled cannot occur here — the route is only registered when the
+	// secret is configured (see api.NewRouter + cmd/main.go). // MODIFIED
 	if verifyErr := h.verifier.Verify(body, sig); verifyErr != nil {
-		if errors.Is(verifyErr, ErrWebhookDisabled) {
-			// Webhook disabled but endpoint still called — return 503.
-			c.JSON(http.StatusServiceUnavailable, api.ErrorResponse{Error: "github webhook not configured"})
-			return
-		}
 		slog.Warn("webhook: signature verification failed", "delivery", delivery, "event", event)
 		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "signature verification failed"})
 		return
@@ -209,7 +204,7 @@ func (h *WebhookHandler) HandleWebhook(c *gin.Context) {
 	}
 
 	// Step 16: Enqueue task.
-	taskID := uuid.New().String()
+	taskID := "" // MODIFIED: removed dead uuid.New() — task.ID is always set on success
 	task, enqErr := h.taskUC.EnqueueFromIssue(ctx, usecase.EnqueueRequest{
 		RepoFullName: repoFullName,
 		IssueNumber:  issueNumber,

--- a/internal/github/webhook_handler_test.go
+++ b/internal/github/webhook_handler_test.go
@@ -1,0 +1,567 @@
+package github_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gs97ahn/scheduled-dev-agent/internal/api"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/config"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/domain"
+	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
+	"github.com/gs97ahn/scheduled-dev-agent/internal/usecase"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// ---------- test doubles ----------
+
+const testWebhookSecret = "test-webhook-secret"
+
+// fakeTaskEnqueuer records calls to EnqueueFromIssue.
+type fakeTaskEnqueuer struct {
+	calls  []usecase.EnqueueRequest
+	result *domain.Task
+	err    error
+}
+
+func (f *fakeTaskEnqueuer) EnqueueFromIssue(_ context.Context, req usecase.EnqueueRequest) (*domain.Task, error) {
+	f.calls = append(f.calls, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &domain.Task{ID: "task-uuid-generated", Status: domain.TaskStatusQueued}, nil
+}
+
+// fakeTaskChecker controls ExistsByRepoAndIssue.
+type fakeTaskChecker struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeTaskChecker) ExistsByRepoAndIssue(_ context.Context, _ string, _ int) (bool, error) {
+	return f.exists, f.err
+}
+
+// fixedDedup always returns the configured bool.
+type fixedDedup struct{ accept bool }
+
+func (d *fixedDedup) CheckAndAdd(_ string) bool { return d.accept }
+
+// ---------- helpers ----------
+
+func sign(t *testing.T, body []byte, secret string) string {
+	t.Helper()
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newGitHubCfg(repos ...config.RepoConfig) *config.GitHubConfig {
+	return &config.GitHubConfig{Repos: repos}
+}
+
+func buildHandler(
+	secret string,
+	dedup igithub.DedupCache,
+	enqueuer *fakeTaskEnqueuer,
+	checker *fakeTaskChecker,
+	cfg *config.GitHubConfig,
+) *gin.Engine {
+	verifier := igithub.NewWebhookVerifier(secret)
+	h := igithub.NewWebhookHandler(verifier, dedup, enqueuer, checker, cfg)
+
+	r := gin.New()
+	r.POST("/github/webhook", h.HandleWebhook)
+	return r
+}
+
+// buildIssuePayload creates a minimal GitHub issues event JSON body.
+func buildIssuePayload(t *testing.T, action, repo string, issueNum int, labels []string, isPR bool) []byte {
+	t.Helper()
+
+	type label struct {
+		Name string `json:"name"`
+	}
+	type issue struct {
+		Number      int       `json:"number"`
+		Title       string    `json:"title"`
+		PullRequest *struct{} `json:"pull_request,omitempty"`
+		Labels      []label   `json:"labels"`
+	}
+	type repository struct {
+		FullName string `json:"full_name"`
+	}
+	type payload struct {
+		Action     string     `json:"action"`
+		Issue      issue      `json:"issue"`
+		Repository repository `json:"repository"`
+	}
+
+	ls := make([]label, len(labels))
+	for i, l := range labels {
+		ls[i] = label{Name: l}
+	}
+
+	var pr *struct{}
+	if isPR {
+		pr = &struct{}{}
+	}
+
+	p := payload{
+		Action: action,
+		Issue: issue{
+			Number:      issueNum,
+			Title:       "Test Issue",
+			PullRequest: pr,
+			Labels:      ls,
+		},
+		Repository: repository{FullName: repo},
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return b
+}
+
+// ---------- tests ----------
+
+func TestWebhookHandler_WebhookDisabled_503(t *testing.T) {
+	// empty secret → verifier returns ErrWebhookDisabled
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg()
+	body := []byte("{}")
+	r := buildHandler("", &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "disabled-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, "any-secret"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when secret is empty, got %d", w.Code)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called when webhook is disabled")
+	}
+}
+
+func TestWebhookHandler_MissingEvent_400(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewBufferString("{}"))
+	req.Header.Set("X-GitHub-Delivery", "uuid-1")
+	req.Header.Set("X-Hub-Signature-256", sign(t, []byte("{}"), testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called")
+	}
+}
+
+func TestWebhookHandler_MissingDelivery_400(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewBufferString("{}"))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-Hub-Signature-256", sign(t, []byte("{}"), testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called")
+	}
+}
+
+func TestWebhookHandler_MissingSignature_401(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewBufferString("{}"))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "uuid-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called")
+	}
+}
+
+func TestWebhookHandler_InvalidSignature_401(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	body := []byte("{}")
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "uuid-1")
+	req.Header.Set("X-Hub-Signature-256", "sha256=invalidsignature")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called")
+	}
+}
+
+func TestWebhookHandler_PingEvent_200(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "ping")
+	req.Header.Set("X-GitHub-Delivery", "ping-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Accepted || resp.Reason != "ping" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for ping")
+	}
+}
+
+func TestWebhookHandler_UnsupportedEvent_200Ignored(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	body := []byte(`{}`)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, newGitHubCfg())
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-GitHub-Delivery", "push-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "ignored:event_not_supported" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called")
+	}
+}
+
+func TestWebhookHandler_DuplicateDelivery_200Duplicate(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{false}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "dup-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "duplicate" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for duplicate delivery")
+	}
+}
+
+func TestWebhookHandler_PREvent_200Ignored(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"claude-ops"}, true)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "pr-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "ignored:pr_event" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for PR event")
+	}
+}
+
+func TestWebhookHandler_UnsupportedAction_200Ignored(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "closed", "owner/repo", 42, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "closed-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "ignored:action" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for unsupported action")
+	}
+}
+
+func TestWebhookHandler_NotInAllowlist_200Ignored(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/allowed-repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/other-repo", 42, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "allowlist-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "ignored:not_in_allowlist" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for non-allowlisted repo")
+	}
+}
+
+func TestWebhookHandler_LabelMismatch_200Ignored(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"other-label"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "label-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "ignored:label_mismatch" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called for label mismatch")
+	}
+}
+
+func TestWebhookHandler_AlreadyExists_200Duplicate(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"claude-ops"}, false)
+	checker := &fakeTaskChecker{exists: true}
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, checker, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "exists-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp api.WebhookResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Accepted || resp.Reason != "duplicate" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if len(enqueuer.calls) != 0 {
+		t.Error("EnqueueFromIssue must not be called when task already exists")
+	}
+}
+
+func TestWebhookHandler_HappyPath_Labeled_200Queued(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "happy-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp api.WebhookResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Accepted || resp.Reason != "queued" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if resp.TaskID == "" {
+		t.Error("task_id must be set in accepted response")
+	}
+	if len(enqueuer.calls) != 1 {
+		t.Fatalf("expected 1 EnqueueFromIssue call, got %d", len(enqueuer.calls))
+	}
+	if enqueuer.calls[0].Source != "webhook" {
+		t.Errorf("expected source=webhook, got %s", enqueuer.calls[0].Source)
+	}
+}
+
+func TestWebhookHandler_HappyPath_Opened_200Queued(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "opened", "owner/repo", 1, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "opened-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(enqueuer.calls) != 1 {
+		t.Fatalf("expected 1 EnqueueFromIssue call, got %d", len(enqueuer.calls))
+	}
+}
+
+// TestWebhookHandler_EnqueueError_500 verifies GitHub can retry on DB failure.
+func TestWebhookHandler_EnqueueError_500(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{err: domain.ErrNotFound}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 42, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "err-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// TestWebhookHandler_InvalidJSON_400 verifies that unparseable bodies return 400.
+func TestWebhookHandler_InvalidJSON_400(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{}
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := []byte("not-json-at-all{{{")
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "json-err-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// TestWebhookHandler_WindowGate_EnqueueOnly verifies US-7:
+// webhook enqueues regardless of active window (scheduler gate is separate).
+// We simulate this by confirming enqueue IS called even at an "odd" time
+// (the window gate is only enforced by TaskUseCase, not the webhook handler itself).
+func TestWebhookHandler_WindowGate_EnqueueOnly(t *testing.T) {
+	enqueuer := &fakeTaskEnqueuer{} // no window gate — handler just calls EnqueueFromIssue
+	cfg := newGitHubCfg(config.RepoConfig{Name: "owner/repo", Labels: []string{"claude-ops"}})
+	body := buildIssuePayload(t, "labeled", "owner/repo", 99, []string{"claude-ops"}, false)
+	r := buildHandler(testWebhookSecret, &fixedDedup{true}, enqueuer, &fakeTaskChecker{}, cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/github/webhook", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "window-uuid")
+	req.Header.Set("X-Hub-Signature-256", sign(t, body, testWebhookSecret))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(enqueuer.calls) != 1 {
+		t.Error("webhook handler must call EnqueueFromIssue; window gate is TaskUseCase's responsibility")
+	}
+	_ = time.Now() // just to confirm no time operations in handler path beyond latency
+}

--- a/internal/github/webhook_handler_test.go
+++ b/internal/github/webhook_handler_test.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/gs97ahn/scheduled-dev-agent/internal/api"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/config"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/domain"
-	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
-	"github.com/gs97ahn/scheduled-dev-agent/internal/usecase"
+	"github.com/gs97ahn/claude-ops/internal/api"
+	"github.com/gs97ahn/claude-ops/internal/config"
+	"github.com/gs97ahn/claude-ops/internal/domain"
+	igithub "github.com/gs97ahn/claude-ops/internal/github"
+	"github.com/gs97ahn/claude-ops/internal/usecase"
 )
 
 func init() {
@@ -142,8 +142,11 @@ func buildIssuePayload(t *testing.T, action, repo string, issueNum int, labels [
 
 // ---------- tests ----------
 
-func TestWebhookHandler_WebhookDisabled_503(t *testing.T) {
-	// empty secret → verifier returns ErrWebhookDisabled
+// TestWebhookHandler_WebhookDisabled_SignatureStillChecked verifies that even without a
+// configured secret the handler itself rejects mismatched signatures (though in production
+// the route is never registered when secret is empty — see api.NewRouter). // MODIFIED
+func TestWebhookHandler_WebhookDisabled_SignatureStillChecked(t *testing.T) { // MODIFIED
+	// empty secret → verifier returns ErrWebhookDisabled (401 for any call)
 	enqueuer := &fakeTaskEnqueuer{}
 	cfg := newGitHubCfg()
 	body := []byte("{}")
@@ -156,8 +159,9 @@ func TestWebhookHandler_WebhookDisabled_503(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusServiceUnavailable {
-		t.Errorf("expected 503 when secret is empty, got %d", w.Code)
+	// Handler returns 401 because empty-secret verifier always fails. // MODIFIED
+	if w.Code != http.StatusUnauthorized { // MODIFIED
+		t.Errorf("expected 401 when secret is empty, got %d", w.Code) // MODIFIED
 	}
 	if len(enqueuer.calls) != 0 {
 		t.Error("EnqueueFromIssue must not be called when webhook is disabled")

--- a/internal/github/webhook_verifier.go
+++ b/internal/github/webhook_verifier.go
@@ -1,3 +1,10 @@
+// Package github provides GitHub webhook verification and delivery deduplication.
+//
+// Replay protection note:
+// GitHub webhook does not provide an official timestamp header
+// (unlike Slack X-Slack-Request-Timestamp). Replay window is
+// implemented at the dedup layer via delivery-ID TTL (default 5min).
+// See docs/specs/github-webhook.md §6.1 for the design decision. // ADDED
 package github
 
 import (

--- a/internal/github/webhook_verifier.go
+++ b/internal/github/webhook_verifier.go
@@ -1,0 +1,63 @@
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrWebhookDisabled is returned when the webhook secret is not configured.
+var ErrWebhookDisabled = errors.New("github webhook disabled: secret not set")
+
+// ErrInvalidWebhookSignature is returned when the HMAC-SHA256 signature does not match.
+var ErrInvalidWebhookSignature = errors.New("invalid github webhook signature")
+
+// ErrMissingSignatureHeader is returned when the X-Hub-Signature-256 header is absent.
+var ErrMissingSignatureHeader = errors.New("missing X-Hub-Signature-256 header")
+
+// WebhookVerifier verifies GitHub webhook HMAC-SHA256 signatures.
+type WebhookVerifier struct {
+	secret []byte
+}
+
+// NewWebhookVerifier creates a WebhookVerifier with the given secret.
+// If secret is empty, all Verify calls will return ErrWebhookDisabled.
+func NewWebhookVerifier(secret string) *WebhookVerifier {
+	return &WebhookVerifier{secret: []byte(secret)}
+}
+
+// Verify checks that signatureHeader matches the HMAC-SHA256 of rawBody.
+// signatureHeader must be in the form "sha256=<hex>".
+// Returns ErrWebhookDisabled if secret is empty, ErrMissingSignatureHeader if header is empty,
+// or ErrInvalidWebhookSignature if the signature does not match.
+func (v *WebhookVerifier) Verify(rawBody []byte, signatureHeader string) error {
+	if len(v.secret) == 0 {
+		return ErrWebhookDisabled
+	}
+	if signatureHeader == "" {
+		return ErrMissingSignatureHeader
+	}
+
+	const prefix = "sha256="
+	if !strings.HasPrefix(signatureHeader, prefix) {
+		return fmt.Errorf("%w: expected sha256= prefix", ErrInvalidWebhookSignature)
+	}
+
+	hexPart := signatureHeader[len(prefix):]
+	gotBytes, err := hex.DecodeString(hexPart)
+	if err != nil {
+		return fmt.Errorf("%w: hex decode error: %w", ErrInvalidWebhookSignature, err)
+	}
+
+	mac := hmac.New(sha256.New, v.secret)
+	mac.Write(rawBody)
+	expectedBytes := mac.Sum(nil)
+
+	if !hmac.Equal(expectedBytes, gotBytes) {
+		return ErrInvalidWebhookSignature
+	}
+	return nil
+}

--- a/internal/github/webhook_verifier_test.go
+++ b/internal/github/webhook_verifier_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"testing"
 
-	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
+	igithub "github.com/gs97ahn/claude-ops/internal/github"
 )
 
 // makeGitHubSignature computes a valid sha256=<hex> signature for the given body and secret.

--- a/internal/github/webhook_verifier_test.go
+++ b/internal/github/webhook_verifier_test.go
@@ -1,0 +1,113 @@
+package github_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	igithub "github.com/gs97ahn/scheduled-dev-agent/internal/github"
+)
+
+// makeGitHubSignature computes a valid sha256=<hex> signature for the given body and secret.
+func makeGitHubSignature(t *testing.T, body []byte, secret string) string {
+	t.Helper()
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestWebhookVerifier_Verify(t *testing.T) {
+	const secret = "github-webhook-secret-1234"
+	body := []byte(`{"action":"labeled","issue":{"number":42}}`)
+
+	tests := []struct {
+		name      string
+		secret    string
+		header    string
+		body      []byte
+		wantErr   error
+		wantErrIs bool
+	}{
+		{
+			name:   "valid signature",
+			secret: secret,
+			header: makeGitHubSignature(t, body, secret),
+			body:   body,
+		},
+		{
+			name:      "disabled: empty secret",
+			secret:    "",
+			header:    makeGitHubSignature(t, body, secret),
+			body:      body,
+			wantErr:   igithub.ErrWebhookDisabled,
+			wantErrIs: true,
+		},
+		{
+			name:      "missing header",
+			secret:    secret,
+			header:    "",
+			body:      body,
+			wantErr:   igithub.ErrMissingSignatureHeader,
+			wantErrIs: true,
+		},
+		{
+			name:      "prefix mismatch: uses v0= instead of sha256=",
+			secret:    secret,
+			header:    "v0=" + hex.EncodeToString([]byte("deadbeef")),
+			body:      body,
+			wantErr:   igithub.ErrInvalidWebhookSignature,
+			wantErrIs: true,
+		},
+		{
+			name:      "hex decode error: non-hex chars after sha256=",
+			secret:    secret,
+			header:    "sha256=ZZZNOTVALIDHEX",
+			body:      body,
+			wantErr:   igithub.ErrInvalidWebhookSignature,
+			wantErrIs: true,
+		},
+		{
+			name:      "wrong secret",
+			secret:    secret,
+			header:    makeGitHubSignature(t, body, "wrong-secret"),
+			body:      body,
+			wantErr:   igithub.ErrInvalidWebhookSignature,
+			wantErrIs: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := igithub.NewWebhookVerifier(tc.secret)
+			err := v.Verify(tc.body, tc.header)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if !tc.wantErrIs {
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected errors.Is(err, %v), got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestWebhookVerifier_GitHubOfficialFixture tests with a known GitHub official-style fixture.
+func TestWebhookVerifier_GitHubOfficialFixture(t *testing.T) {
+	// Values derived from GitHub docs example pattern.
+	secret := "It's a Secret to Everybody"
+	body := []byte("Hello, World!")
+
+	sig := makeGitHubSignature(t, body, secret)
+
+	v := igithub.NewWebhookVerifier(secret)
+	if err := v.Verify(body, sig); err != nil {
+		t.Fatalf("official fixture verification failed: %v", err)
+	}
+}

--- a/internal/usecase/task_usecase.go
+++ b/internal/usecase/task_usecase.go
@@ -55,6 +55,7 @@ type EnqueueRequest struct {
 	RepoFullName string
 	IssueNumber  int
 	IssueTitle   string
+	Source       string // "webhook" | "polling" | "" (manual)
 }
 
 // TaskDetail is the usecase response for a single task with its recent events.


### PR DESCRIPTION
## Summary
- 5개 후속 기능의 PRD를 먼저 정착시키고, 그중 첫 구현으로 GitHub webhook receiver를 추가합니다 (Resolves OI-5).
- `POST /github/webhook` — HMAC-SHA256 검증 + delivery-ID dedup + repo/label allowlist 통과 시 즉시 task enqueue.
- Polling은 fallback으로 그대로 유지 — 누락된 delivery는 다음 tick에서 회수.

## Changes

**docs/specs/** — 5개 기능 PRD + Go 구현 가이드 (`add9850`)
- `github-webhook` (이번 PR 구현 대상)
- `ci-fix-loop`, `usage-dashboard`, `pr-reviewer-assign`, `parallel-tasks` (후속 PR 예정)

**internal/github/** — webhook 구현 (`341359e`)
- `webhook_verifier.go` — `crypto/hmac` 기반 서명 검증
- `webhook_dedup.go` — in-memory delivery-ID TTL 캐시 + 백그라운드 GC
- `webhook_handler.go` — Gin handler (allowlist · 라벨 필터 · enqueue)

**security review fixes** (`8f5d7fe`)
- dedup TOCTOU race 수정 (`sync.Map` → `sync.Mutex` + map)
- secret 미설정 시 라우트 등록 자체 생략 (endpoint 노출 surface 제거)
- 죽은 `uuid.New()` 제거
- replay-window 설계 결정 코드 주석화 (GitHub은 timestamp 헤더 미제공 → dedup TTL이 대체)

**기타**
- `internal/usecase/task_usecase.go` — `EnqueueRequest.Source` (`"polling"` | `"webhook"`)
- `internal/config/{config,validate}.go` — `GITHUB_WEBHOOK_SECRET` env
- `internal/api/{server,dto}.go` — 라우트 + DTO

## Test plan
- [x] 단위 테스트: verifier 100%, dedup 100% (TTL 경계 race 테스트 포함), handler 92.5%
- [x] `go test -race ./...` 통과
- [x] `golangci-lint run ./...` 0 issues
- [x] 시나리오: 정상 issues 이벤트 → 200 + task enqueue / 잘못된 서명 → 401 / 미허용 repo → 무시 / 중복 delivery → 1회만 enqueue
- [ ] 운영 환경에서 실제 GitHub webhook 등록 후 latency p95 측정 (PRD G1: < 2s)
- [ ] secret 미설정 운영 시 `/github/webhook` 404 확인

## Notes
- **bundle 주의**: `add9850` 커밋은 5개 기능 PRD를 함께 포함합니다. webhook 외 4개 PRD는 후속 PR 구현 대상이며 이 PR에서는 문서만 추가됩니다.
- 후속 작업: `ci-fix-loop` → `usage-dashboard` → `pr-reviewer-assign` → `parallel-tasks` (마지막은 §6.5 ramp-up 권장)