### PR TITLE
chore(deploy): switch host path prefix to nogamsung

### DIFF
--- a/deployments/deploy.sh
+++ b/deployments/deploy.sh
@@ -8,12 +8,12 @@ OUTER_PORT=8787
 INNER_PORT=8787
 IMAGE="ghcr.io/nogamsung/claude-ops:latest"
 
-ENV_FILE="/home/gs97ahn/app/env/claude-ops"
-CONFIG_FILE="/home/gs97ahn/app/claude-ops/config.yaml"
-DATA_DIR="/home/gs97ahn/app/claude-ops/data"
-WORKTREE_DIR="/home/gs97ahn/app/claude-ops/.worktrees"
-PROMPTS_DIR="/home/gs97ahn/app/claude-ops/prompts"
-LOG_DIR="/home/gs97ahn/app/claude-ops/logs"
+ENV_FILE="/home/nogamsung/app/env/claude-ops"
+CONFIG_FILE="/home/nogamsung/app/claude-ops/config.yaml"
+DATA_DIR="/home/nogamsung/app/claude-ops/data"
+WORKTREE_DIR="/home/nogamsung/app/claude-ops/.worktrees"
+PROMPTS_DIR="/home/nogamsung/app/claude-ops/prompts"
+LOG_DIR="/home/nogamsung/app/claude-ops/logs"
 
 # Host 에 이미 'claude login' / 'gh auth login' 이 완료돼 있어야 함 (PRD §9).
 # 컨테이너는 agent 유저로 구동되지만 HOME 은 /root 로 고정되므로 /root 에 마운트.


### PR DESCRIPTION
## Summary
- `deployments/deploy.sh` 의 호스트 경로 prefix 를 `/home/gs97ahn/app` → `/home/nogamsung/app` 으로 변경
- dev 호스트의 운영 계정이 `nogamsung` 으로 통일된 데 따른 단순 패치

## Changes
- `ENV_FILE`, `CONFIG_FILE`, `DATA_DIR`, `WORKTREE_DIR`, `PROMPTS_DIR`, `LOG_DIR` 6개 변수 prefix 치환 (총 6줄)

## Test plan
- [ ] dev 호스트에서 `bash deployments/deploy.sh` 가 정상 실행되는지 확인
- [ ] `/home/nogamsung/app/claude-ops/{env,config.yaml,data,prompts,logs,.worktrees}` 경로가 사전에 준비돼 있는지 확인
- [ ] 컨테이너가 정상 기동 후 `docker logs claude-ops` 에서 부팅 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)